### PR TITLE
docs: Add plugin update instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
 
 2. **That's it!** opencode will auto-install the plugin on first run.
 
+   > **Note on Updates**: opencode does NOT automatically update plugins to new versions. To update:
+   > - Pin to a specific version: `"opencode-openai-codex-auth@1.0.3"` and change the number when updating
+   > - Or clear the plugin cache: `rm -rf ~/.cache/opencode/node_modules/opencode-openai-codex-auth`
+   >
+   > Check [releases](https://github.com/numman-ali/opencode-openai-codex-auth/releases) for the latest version.
+
 > **New to opencode?** Learn more:
 > - [Configuration Guide](https://opencode.ai/docs/config/)
 > - [Plugin Documentation](https://opencode.ai/docs/plugins/)


### PR DESCRIPTION
## Summary

Adds documentation to clarify that opencode does **not** automatically update plugins when new versions are published to npm.

Closes #4

## Changes

- Added note in README explaining plugin update behavior
- Documented two methods for users to upgrade plugins:
  1. Pin specific versions in config (recommended)
  2. Clear plugin cache manually

## Why This Matters

Users may miss bug fixes and new features because they stay on the initially installed version. This PR gives them a clear upgrade path.

## Test Plan

- Verified instructions match actual opencode behavior
- Tested version pinning: `"opencode-openai-codex-auth@1.0.3"`
- Tested cache clearing method

## Screenshots

The new documentation appears right after installation instructions, making it visible to all users during setup.