### PR TITLE
feat: Add user-configurable settings for reasoning and text verbosity

### DIFF
--- a/lib/request-transformer.mjs
+++ b/lib/request-transformer.mjs
@@ -19,17 +19,43 @@ export function normalizeModel(model) {
 }
 
 /**
- * Configure reasoning parameters based on model variant
+ * Extract configuration for a specific model
+ * Merges global options with model-specific options (model-specific takes precedence)
+ * @param {string} modelName - Model name (e.g., "gpt-5-codex")
+ * @param {object} userConfig - Full user configuration object
+ * @returns {object} Merged configuration for this model
+ */
+export function getModelConfig(modelName, userConfig = {}) {
+	const globalOptions = userConfig.global || {};
+	const modelOptions = userConfig.models?.[modelName]?.options || {};
+
+	// Model-specific options override global options
+	return { ...globalOptions, ...modelOptions };
+}
+
+/**
+ * Configure reasoning parameters based on model variant and user config
+ *
+ * NOTE: This plugin follows Codex CLI defaults instead of opencode defaults because:
+ * - We're accessing the ChatGPT backend API (not OpenAI Platform API)
+ * - opencode explicitly excludes gpt-5-codex from automatic reasoning configuration
+ * - Codex CLI has been thoroughly tested against this backend
+ *
  * @param {string} originalModel - Original model name before normalization
+ * @param {object} userConfig - User configuration object
  * @returns {object} Reasoning configuration
  */
-export function getReasoningConfig(originalModel) {
+export function getReasoningConfig(originalModel, userConfig = {}) {
 	const isLightweight =
 		originalModel?.includes("nano") || originalModel?.includes("mini");
 
+	// Default based on model type (Codex CLI defaults)
+	const defaultEffort = isLightweight ? "minimal" : "medium";
+
 	return {
-		effort: isLightweight ? "minimal" : "high",
-		summary: "detailed", // Only supported value for gpt-5
+		// User config takes precedence, otherwise use defaults
+		effort: userConfig.reasoningEffort || defaultEffort,
+		summary: userConfig.reasoningSummary || "auto", // Changed from "detailed" to match Codex CLI
 	};
 }
 
@@ -75,15 +101,26 @@ export function addToolRemapMessage(input, hasTools) {
 
 /**
  * Transform request body for Codex API
+ *
+ * NOTE: Configuration follows Codex CLI patterns instead of opencode defaults:
+ * - opencode sets textVerbosity="low" for gpt-5, but Codex CLI uses "medium"
+ * - opencode excludes gpt-5-codex from reasoning configuration
+ * - This plugin uses store=false (stateless), requiring encrypted reasoning content
+ *
  * @param {object} body - Original request body
  * @param {string} codexInstructions - Codex system instructions
+ * @param {object} userConfig - User configuration from loader
  * @returns {object} Transformed request body
  */
-export function transformRequestBody(body, codexInstructions) {
+export function transformRequestBody(body, codexInstructions, userConfig = {}) {
 	const originalModel = body.model;
+	const normalizedModel = normalizeModel(body.model);
+
+	// Get model-specific configuration (merges global + per-model options)
+	const modelConfig = getModelConfig(normalizedModel, userConfig);
 
 	// Normalize model name
-	body.model = normalizeModel(body.model);
+	body.model = normalizedModel;
 
 	// Codex required fields
 	body.store = false;
@@ -96,18 +133,24 @@ export function transformRequestBody(body, codexInstructions) {
 		body.input = addToolRemapMessage(body.input, !!body.tools);
 	}
 
-	// Configure reasoning
-	const reasoningConfig = getReasoningConfig(originalModel);
+	// Configure reasoning (use model-specific config)
+	const reasoningConfig = getReasoningConfig(originalModel, modelConfig);
 	body.reasoning = {
 		...body.reasoning,
 		...reasoningConfig,
 	};
 
-	// Configure text verbosity
+	// Configure text verbosity (support user config)
+	// Default: "medium" (matches Codex CLI default for all GPT-5 models)
 	body.text = {
 		...body.text,
-		verbosity: "medium",
+		verbosity: modelConfig.textVerbosity || "medium",
 	};
+
+	// Add include for encrypted reasoning content
+	// Default: ["reasoning.encrypted_content"] (required for stateless operation with store=false)
+	// This allows reasoning context to persist across turns without server-side storage
+	body.include = modelConfig.include || ["reasoning.encrypted_content"];
 
 	// Remove unsupported parameters
 	body.max_output_tokens = undefined;

--- a/lib/request-transformer.mjs
+++ b/lib/request-transformer.mjs
@@ -48,13 +48,23 @@ export function getModelConfig(modelName, userConfig = {}) {
 export function getReasoningConfig(originalModel, userConfig = {}) {
 	const isLightweight =
 		originalModel?.includes("nano") || originalModel?.includes("mini");
+	const isCodex = originalModel?.includes("codex");
 
 	// Default based on model type (Codex CLI defaults)
 	const defaultEffort = isLightweight ? "minimal" : "medium";
 
+	// Get user-requested effort
+	let effort = userConfig.reasoningEffort || defaultEffort;
+
+	// Normalize "minimal" to "low" for gpt-5-codex
+	// Codex CLI does not provide a "minimal" preset for gpt-5-codex
+	// (only low/medium/high - see model_presets.rs:20-40)
+	if (isCodex && effort === "minimal") {
+		effort = "low";
+	}
+
 	return {
-		// User config takes precedence, otherwise use defaults
-		effort: userConfig.reasoningEffort || defaultEffort,
+		effort,
 		summary: userConfig.reasoningSummary || "auto", // Changed from "detailed" to match Codex CLI
 	};
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenAI ChatGPT (Codex backend) OAuth auth plugin for opencode - use your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./index.mjs",
   "type": "module",

--- a/test-config.json
+++ b/test-config.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["file:///home/code/projects/ben-vargas/ai-opencode-openai-codex-auth/config-support"],
+  "model": "openai/gpt-5-codex",
+  "provider": {
+    "openai": {
+      "options": {
+        "reasoningEffort": "medium",
+        "reasoningSummary": "auto",
+        "textVerbosity": "medium"
+      },
+      "models": {
+        "gpt-5-codex": {
+          "options": {
+            "reasoningSummary": "concise"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-config.mjs
+++ b/test-config.mjs
@@ -87,9 +87,22 @@ console.log("Test 5: Lightweight model (gpt-5-nano)");
 const nanoReasoning = getReasoningConfig("gpt-5-nano", {});
 console.log("Nano reasoning:", nanoReasoning);
 console.log("Expected: effort='minimal' (lightweight default), summary='auto'");
-console.log("✓ Pass:", 
+console.log("✓ Pass:",
 	nanoReasoning.effort === "minimal" &&
 	nanoReasoning.summary === "auto"
+);
+console.log("\n");
+
+// Test 6: Normalize "minimal" to "low" for gpt-5-codex
+console.log("Test 6: Normalize minimal→low for gpt-5-codex (Codex CLI doesn't support minimal)");
+const codexMinimalConfig = { reasoningEffort: "minimal" };
+const codexMinimalReasoning = getReasoningConfig("gpt-5-codex", codexMinimalConfig);
+console.log("Config:", codexMinimalConfig);
+console.log("Reasoning result:", codexMinimalReasoning);
+console.log("Expected: effort='low' (normalized from minimal), summary='auto'");
+console.log("✓ Pass:",
+	codexMinimalReasoning.effort === "low" &&
+	codexMinimalReasoning.summary === "auto"
 );
 
 console.log("\n=== All Tests Complete ===");

--- a/test-config.mjs
+++ b/test-config.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { getModelConfig, getReasoningConfig } from "./lib/request-transformer.mjs";
+
+console.log("=== Testing Configuration Parsing ===\n");
+
+// Simulate provider config from opencode.json
+const providerConfig = {
+	options: {
+		reasoningEffort: "medium",
+		reasoningSummary: "auto",
+		textVerbosity: "medium",
+	},
+	models: {
+		"gpt-5-codex": {
+			options: {
+				reasoningSummary: "concise", // Override global
+			},
+		},
+		"gpt-5": {
+			options: {
+				reasoningEffort: "high", // Override global
+			},
+		},
+	},
+};
+
+// Build userConfig structure (same as in index.mjs)
+const userConfig = {
+	global: providerConfig.options || {},
+	models: providerConfig.models || {},
+};
+
+console.log("Provider Config:");
+console.log(JSON.stringify(providerConfig, null, 2));
+console.log("\n");
+
+// Test 1: gpt-5-codex (should merge global + model-specific)
+console.log("Test 1: gpt-5-codex configuration");
+const codexConfig = getModelConfig("gpt-5-codex", userConfig);
+console.log("Merged config:", codexConfig);
+console.log("Expected: reasoningEffort='medium' (global), reasoningSummary='concise' (override), textVerbosity='medium' (global)");
+console.log("✓ Pass:", 
+	codexConfig.reasoningEffort === "medium" &&
+	codexConfig.reasoningSummary === "concise" &&
+	codexConfig.textVerbosity === "medium"
+);
+console.log("\n");
+
+// Test 2: gpt-5 (should merge global + model-specific)
+console.log("Test 2: gpt-5 configuration");
+const gpt5Config = getModelConfig("gpt-5", userConfig);
+console.log("Merged config:", gpt5Config);
+console.log("Expected: reasoningEffort='high' (override), reasoningSummary='auto' (global), textVerbosity='medium' (global)");
+console.log("✓ Pass:", 
+	gpt5Config.reasoningEffort === "high" &&
+	gpt5Config.reasoningSummary === "auto" &&
+	gpt5Config.textVerbosity === "medium"
+);
+console.log("\n");
+
+// Test 3: Reasoning config with user settings
+console.log("Test 3: Reasoning config for gpt-5-codex");
+const reasoningConfig = getReasoningConfig("gpt-5-codex", codexConfig);
+console.log("Reasoning config:", reasoningConfig);
+console.log("Expected: effort='medium', summary='concise'");
+console.log("✓ Pass:", 
+	reasoningConfig.effort === "medium" &&
+	reasoningConfig.summary === "concise"
+);
+console.log("\n");
+
+// Test 4: Defaults when no config provided
+console.log("Test 4: Defaults with empty config");
+const emptyConfig = getModelConfig("gpt-5-codex", {});
+const defaultReasoning = getReasoningConfig("gpt-5-codex", emptyConfig);
+console.log("Empty config:", emptyConfig);
+console.log("Default reasoning:", defaultReasoning);
+console.log("Expected: effort='medium' (default), summary='auto' (default)");
+console.log("✓ Pass:", 
+	defaultReasoning.effort === "medium" &&
+	defaultReasoning.summary === "auto"
+);
+console.log("\n");
+
+// Test 5: Lightweight model defaults
+console.log("Test 5: Lightweight model (gpt-5-nano)");
+const nanoReasoning = getReasoningConfig("gpt-5-nano", {});
+console.log("Nano reasoning:", nanoReasoning);
+console.log("Expected: effort='minimal' (lightweight default), summary='auto'");
+console.log("✓ Pass:", 
+	nanoReasoning.effort === "minimal" &&
+	nanoReasoning.summary === "auto"
+);
+
+console.log("\n=== All Tests Complete ===");


### PR DESCRIPTION
## Summary

This PR adds comprehensive user-configurable settings support to the plugin, allowing users to customize reasoning effort, reasoning summaries, text verbosity, and response fields for both `gpt-5` and `gpt-5-codex` models through opencode's configuration system.

## What's New

### 🎛️ User-Configurable Settings

Users can now customize model behavior via `opencode.json` configuration:

- **`reasoningEffort`**: Control computational effort (`minimal`, `low`, `medium`, `high`)
- **`reasoningSummary`**: Control summary verbosity (`auto`, `detailed`)
- **`textVerbosity`**: Control output length (`low`, `medium`, `high` - codex only supports `medium`)
- **`include`**: Additional response fields (default: `["reasoning.encrypted_content"]` for stateless reasoning)

### 🎯 Flexible Configuration Patterns

The plugin supports three configuration patterns following Anthropic's configuration approach:

1. **Global options**: Apply same settings to all GPT-5 models
2. **Per-model options**: Different settings for `gpt-5` vs `gpt-5-codex`
3. **Mixed configuration**: Global defaults with per-model overrides

Per-model options take precedence over global options when both are specified.

### 📊 Updated Plugin Defaults

The plugin defaults have been updated to match Codex CLI behavior and provide better out-of-the-box performance:

**New defaults (v1.0.4):**
```json
{
  "reasoningEffort": "medium",
  "reasoningSummary": "auto",
  "textVerbosity": "medium",
  "include": ["reasoning.encrypted_content"]
}
```

**Previous defaults (v1.0.3):**
```json
{
  "reasoningEffort": "high",
  "reasoningSummary": "detailed",
  "textVerbosity": "medium"
}
```

**Changes:**
- `reasoningEffort`: Changed from `high` → `medium` (more balanced performance/cost)
- `reasoningSummary`: Changed from `detailed` → `auto` (matches Codex CLI default)
- `include`: Added `["reasoning.encrypted_content"]` (critical for stateless multi-turn conversations)

The `include: ["reasoning.encrypted_content"]` default is critical for stateless operation (`store: false`), allowing reasoning context to persist across turns without server-side storage.

### ✅ Model-Specific Validation

The implementation includes model-specific restrictions based on comprehensive testing:

**GPT-5 Model:**
- `reasoningEffort`: `minimal`, `low`, `medium`, `high`
- `reasoningSummary`: `auto`, `detailed`
- `textVerbosity`: `low`, `medium`, `high`

**GPT-5-Codex Model:**
- `reasoningEffort`: `minimal`* (auto-normalized to `low`), `low`, `medium`, `high`
- `reasoningSummary`: `auto`, `detailed`
- `textVerbosity`: `medium` only

**Both Models:**
- `include`: Array of strings (default: `["reasoning.encrypted_content"]`)

\* The plugin automatically normalizes `minimal` → `low` for gpt-5-codex to match Codex CLI behavior.

## Implementation Details

### Configuration Loader (`index.mjs`)

- Extracts user configuration from opencode's provider options
- Supports both `provider.openai.options` (global) and `provider.openai.models.{model}.options` (per-model)
- Passes configuration to request transformer

### Request Transformer (`lib/request-transformer.mjs`)

- New `getModelConfig()`: Merges global + per-model options (per-model overrides)
- Enhanced `getReasoningConfig()`: Accepts user config, applies defaults, normalizes values
- Enhanced `transformRequestBody()`: Applies user-configured text verbosity, reasoning settings, and include fields
- Automatic normalization of `minimal` → `low` for gpt-5-codex
- Configurable `include` field with default for encrypted reasoning content

### Testing (`test-config.mjs`)

- Comprehensive unit tests for configuration parsing
- Tests global options, per-model options, and mixed configurations
- Validates merging logic and default values
- Run with: `node test-config.mjs`

## Documentation

Updated `README.md` with:
- Clear tables showing supported values for each model (including `include` setting)
- Three configuration examples (global, per-model, mixed)
- Plugin defaults section explaining the importance of `reasoning.encrypted_content`
- Model-specific restrictions and warnings

## Example Configuration

```json
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": ["opencode-openai-codex-auth"],
  "model": "openai/gpt-5-codex",
  "provider": {
    "openai": {
      "options": {
        "reasoningEffort": "medium",
        "reasoningSummary": "auto",
        "textVerbosity": "medium",
        "include": ["reasoning.encrypted_content"]
      },
      "models": {
        "gpt-5-codex": {
          "options": {
            "reasoningEffort": "high",
            "reasoningSummary": "detailed"
          }
        }
      }
    }
  }
}
```

**To restore v1.0.3 behavior:**
```json
{
  "provider": {
    "openai": {
      "options": {
        "reasoningEffort": "high",
        "reasoningSummary": "detailed"
      }
    }
  }
}
```

## Testing

All configuration patterns have been tested with:
- Request logging verification (`ENABLE_PLUGIN_REQUEST_LOGGING=1`)
- Systematic testing of all value combinations for reasoning and text verbosity
- Validation against ChatGPT backend API responses
- Unit tests for configuration parsing and merging logic

## Commits

1. **feat: Add user-configurable settings support** - Core implementation
2. **test: Add configuration parsing tests** - Unit tests for config loader
3. **docs: Update README with configuration documentation** - Complete user documentation
4. **fix: Normalize 'minimal' to 'low' for gpt-5-codex** - Match Codex CLI behavior
5. **chore: Bump version to 1.0.4** - Version update for new feature

## Breaking Changes

**Default behavior has changed:**

Users upgrading from v1.0.3 to v1.0.4 will experience different default reasoning behavior:
- Reasoning effort reduced from `high` → `medium` (more balanced dynamic behavior, recommended by OpenAI)
- Reasoning summary changed from `detailed` → `auto` (adaptive verbosity)
- Added encrypted reasoning content for better multi-turn conversations

**Rationale:** The new defaults match Codex CLI behavior and provide better out-of-the-box performance. The previous `high` effort setting is against default Codex CLI behavior and OpenAI's recommendation of medium which will dynamically think longer or shorter - also improved speed for users.

**To restore v1.0.3 behavior:** Add the configuration shown in the example above to explicitly set `reasoningEffort: "high"` and `reasoningSummary: "detailed"`.