### PR TITLE
Make filterInput stateless-safe (strip ids, drop item_reference) + test updates

### DIFF
--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -92,18 +92,15 @@ export function getReasoningConfig(
  * @returns Filtered input array
  */
 export function filterInput(
-	input: InputItem[] | undefined,
+  input: InputItem[] | undefined,
 ): InputItem[] | undefined {
-	if (!Array.isArray(input)) return input;
+  if (!Array.isArray(input)) return input;
 
-	return input.filter((item) => {
-		// Keep items without IDs (new messages)
-		if (!item.id) return true;
-		// Remove items with response/result IDs (rs_*)
-		if (item.id?.startsWith("rs_")) return false;
-		return true;
-	});
+  return input
+    .filter((item) => item.type !== "item_reference")
+    .map(({ id, ...rest }) => rest);
 }
+
 
 /**
  * Check if an input item is the OpenCode system prompt


### PR DESCRIPTION
### Problem
Codex backend raised `Item ... not found` when `store:false` because messages carried server-generated ids (`rs_`, `msg_`, etc.), causing unintended dereferencing.

### Solution
- Removed all `item_reference` items entirely.
- Kept real items but **stripped their `id` fields**, preserving message content and order.

### Changes
- `filterInput()` now filters out `item_reference` and maps items to omit `id`.
- Updated tests:
  - Adjusted expectations (items kept, IDs undefined).
  - Improved test names for clarity.

### Related Issue
Fixes #21
