### PR TITLE
feat: Support gpt-5.1-codex-max and xhigh reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
 ## Features
 
 - ✅ **ChatGPT Plus/Pro OAuth authentication** - Use your existing subscription
-- ✅ **8 pre-configured GPT 5.1 variants** - GPT 5.1, GPT 5.1 Codex, and GPT 5.1 Codex Mini presets for common reasoning levels
+- ✅ **12 pre-configured GPT 5.1 variants** - GPT 5.1 Codex Max, GPT 5.1, GPT 5.1 Codex, and GPT 5.1 Codex Mini presets
 - ⚠️ **GPT 5.1 only** - Older GPT 5.0 models are deprecated and may not work reliably
 - ✅ **Zero external dependencies** - Lightweight with only @openauthjs/openauth
 - ✅ **Auto-refreshing tokens** - Handles token expiration automatically
@@ -82,6 +82,70 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
         "store": false
       },
       "models": {
+        "gpt-5.1-codex-max-low": {
+          "name": "GPT 5.1 Codex Max Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-medium": {
+          "name": "GPT 5.1 Codex Max Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-high": {
+          "name": "GPT 5.1 Codex Max High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-xhigh": {
+          "name": "GPT 5.1 Codex Max XHigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.1-codex-low": {
           "name": "GPT 5.1 Codex Low (OAuth)",
           "limit": {
@@ -219,12 +283,13 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
    **Global config**: `~/.config/opencode/opencode.json`
    **Project config**: `<project>/.opencode.json`
 
-   This gives you 8 GPT 5.1 variants with different reasoning levels:
+   This gives you 12 GPT 5.1 variants with different reasoning levels:
+   - **gpt-5.1-codex-max** (low/medium/high/xhigh) - Latest Codex-optimized flagship for deep reasoning
    - **gpt-5.1-codex** (low/medium/high) - Latest Codex model presets
    - **gpt-5.1-codex-mini** (medium/high) - Latest Codex mini tier presets
    - **gpt-5.1** (low/medium/high) - Latest general-purpose reasoning presets
 
-   All appear in the opencode model selector as "GPT 5.1 Codex Low (OAuth)", "GPT 5.1 High (OAuth)", etc.
+   All appear in the opencode model selector as "GPT 5.1 Codex Max Low (OAuth)", "GPT 5.1 Codex Low (OAuth)", etc.
 
 ### Prompt caching & usage limits
 
@@ -290,6 +355,10 @@ Check [releases](https://github.com/numman-ali/opencode-openai-codex-auth/releas
 If using the full configuration, select from the model picker in opencode, or specify via command line:
 
 ```bash
+# Use different reasoning levels for gpt-5.1-codex-max
+opencode run "complex architectural task" --model=openai/gpt-5.1-codex-max-xhigh
+opencode run "refactor codebase" --model=openai/gpt-5.1-codex-max-high
+
 # Use different reasoning levels for gpt-5.1-codex
 opencode run "simple task" --model=openai/gpt-5.1-codex-low
 opencode run "complex task" --model=openai/gpt-5.1-codex-high
@@ -309,6 +378,10 @@ When using [`config/full-opencode.json`](./config/full-opencode.json), you get t
 
 | CLI Model ID | TUI Display Name | Reasoning Effort | Best For |
 |--------------|------------------|-----------------|----------|
+| `gpt-5.1-codex-max-low` | GPT 5.1 Codex Max Low (OAuth) | Low | Fast responses with lighter reasoning |
+| `gpt-5.1-codex-max-medium` | GPT 5.1 Codex Max Medium (OAuth) | Medium | Balanced speed and reasoning depth |
+| `gpt-5.1-codex-max-high` | GPT 5.1 Codex Max High (OAuth) | High | Complex problems |
+| `gpt-5.1-codex-max-xhigh` | GPT 5.1 Codex Max XHigh (OAuth) | XHigh | Extra high reasoning depth |
 | `gpt-5.1-codex-low` | GPT 5.1 Codex Low (OAuth) | Low | Fast code generation |
 | `gpt-5.1-codex-medium` | GPT 5.1 Codex Medium (OAuth) | Medium | Balanced code tasks |
 | `gpt-5.1-codex-high` | GPT 5.1 Codex High (OAuth) | High | Complex code & tools |
@@ -364,7 +437,7 @@ These defaults match the official Codex CLI behavior and can be customized (see 
 ### ⚠️ REQUIRED: Use Pre-Configured File
 
 **YOU MUST use [`config/full-opencode.json`](./config/full-opencode.json)** - this is the only officially supported configuration:
-- 8 pre-configured GPT 5.1 model variants with verified settings
+- 12 pre-configured GPT 5.1 model variants with verified settings
 - Optimal configuration for each reasoning level
 - All variants visible in the opencode model selector
 - Required metadata for OpenCode features to work properly
@@ -379,16 +452,16 @@ If you want to customize settings yourself, you can configure options at provide
 
 #### Available Settings
 
-⚠️ **Important**: The two base models have different supported values.
+⚠️ **Important**: The base models have different supported values.
 
-| Setting | GPT-5 Values | GPT-5-Codex Values | Plugin Default |
-|---------|-------------|-------------------|----------------|
-| `reasoningEffort` | `minimal`, `low`, `medium`, `high` | `low`, `medium`, `high` | `medium` |
-| `reasoningSummary` | `auto`, `detailed` | `auto`, `detailed` | `auto` |
-| `textVerbosity` | `low`, `medium`, `high` | `medium` only | `medium` |
-| `include` | Array of strings | Array of strings | `["reasoning.encrypted_content"]` |
+| Setting | GPT-5-Codex-Max Values | GPT-5 Values | GPT-5-Codex Values | Plugin Default |
+|---------|------------------------|-------------|-------------------|----------------|
+| `reasoningEffort` | `low`, `medium`, `high`, `xhigh` | `minimal`, `low`, `medium`, `high` | `low`, `medium`, `high` | `medium` |
+| `reasoningSummary` | `auto`, `detailed` | `auto`, `detailed` | `auto`, `detailed` | `auto` |
+| `textVerbosity` | `medium` only | `low`, `medium`, `high` | `medium` only | `medium` |
+| `include` | Array of strings | Array of strings | Array of strings | `["reasoning.encrypted_content"]` |
 
-> **Note**: `minimal` effort is auto-normalized to `low` for gpt-5-codex (not supported by the API).
+> **Note**: `minimal` effort is auto-normalized to `low` for gpt-5-codex (not supported by the API). `gpt-5.1-codex-max` supports `xhigh`.
 
 #### Global Configuration Example
 

--- a/config/README.md
+++ b/config/README.md
@@ -14,13 +14,13 @@ cp config/full-opencode.json ~/.config/opencode/opencode.json
 
 **Why this is required:**
 - GPT 5 models can be temperamental and need proper configuration
-- Contains 8 verified GPT 5.1 model variants (Codex, Codex Mini, and general GPT 5.1)
+- Contains 12 verified GPT 5.1 model variants (Codex Max, Codex, Codex Mini, and general GPT 5.1)
 - Includes all required metadata for OpenCode features
 - Guaranteed to work reliably
 - Global options for all models + per-model configuration overrides
 
 **What's included:**
-- All supported GPT 5.1 variants: gpt-5.1, gpt-5.1-codex, gpt-5.1-codex-mini
+- All supported GPT 5.1 variants: gpt-5.1-codex-max, gpt-5.1, gpt-5.1-codex, gpt-5.1-codex-mini
 - Proper reasoning effort settings for each variant
 - Context limits (272k context / 128k output)
 - Required options: `store: false`, `include: ["reasoning.encrypted_content"]`

--- a/config/full-opencode.json
+++ b/config/full-opencode.json
@@ -15,6 +15,70 @@
         "store": false
       },
       "models": {
+        "gpt-5.1-codex-max-low": {
+          "name": "GPT 5.1 Codex Max Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-medium": {
+          "name": "GPT 5.1 Codex Max Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-high": {
+          "name": "GPT 5.1 Codex Max High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-codex-max-xhigh": {
+          "name": "GPT 5.1 Codex Max XHigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.1-codex-low": {
           "name": "GPT 5.1 Codex Low (OAuth)",
           "limit": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,20 @@ Complete reference for configuring the OpenCode OpenAI Codex Auth Plugin.
         "store": false
       },
       "models": {
+        "gpt-5.1-codex-max-low": {
+          "name": "GPT 5.1 Codex Max Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": ["reasoning.encrypted_content"],
+            "store": false
+          }
+        },
         "gpt-5.1-codex-low": {
           "name": "GPT 5.1 Codex Low (OAuth)",
           "limit": {
@@ -46,6 +60,12 @@ Complete reference for configuring the OpenCode OpenAI Codex Auth Plugin.
 
 Controls computational effort for reasoning.
 
+**GPT-5.1-Codex-Max Values:**
+- `low` - Fast responses
+- `medium` - Balanced (default)
+- `high` - Deep reasoning
+- `xhigh` - Extra high reasoning depth
+
 **GPT-5 Values:**
 - `minimal` - Fastest, least reasoning
 - `low` - Light reasoning
@@ -60,12 +80,13 @@ Controls computational effort for reasoning.
 **Notes**:
 - `minimal` auto-converts to `low` for gpt-5-codex (API limitation)
 - `gpt-5-codex-mini*` and `gpt-5.1-codex-mini*` only support `medium` or `high`; lower settings are clamped to `medium`
+- `xhigh` is only supported by `gpt-5.1-codex-max`
 
 **Example:**
 ```json
 {
   "options": {
-    "reasoningEffort": "high"
+    "reasoningEffort": "xhigh"
   }
 }
 ```
@@ -96,7 +117,7 @@ Controls output length.
 - `medium` - Balanced (default)
 - `high` - Verbose
 
-**GPT-5-Codex:**
+**GPT-5-Codex & GPT-5.1-Codex-Max:**
 - `medium` only (API limitation)
 
 **Example:**

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -13,6 +13,15 @@
  */
 export const MODEL_MAP: Record<string, string> = {
 	// ============================================================================
+	// GPT-5.1 Codex Max Models
+	// ============================================================================
+	"gpt-5.1-codex-max": "gpt-5.1-codex-max",
+	"gpt-5.1-codex-max-low": "gpt-5.1-codex-max",
+	"gpt-5.1-codex-max-medium": "gpt-5.1-codex-max",
+	"gpt-5.1-codex-max-high": "gpt-5.1-codex-max",
+	"gpt-5.1-codex-max-xhigh": "gpt-5.1-codex-max",
+
+	// ============================================================================
 	// GPT-5.1 Codex Models
 	// ============================================================================
 	"gpt-5.1-codex": "gpt-5.1-codex",

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -38,7 +38,15 @@ export function normalizeModel(model: string | undefined): string {
 	const normalized = modelId.toLowerCase();
 
 	// Priority order for pattern matching (most specific first):
-	// 1. GPT-5.1 Codex Mini
+	// 1. GPT-5.1 Codex Max
+	if (
+		normalized.includes("gpt-5.1-codex-max") ||
+		normalized.includes("gpt 5.1 codex max")
+	) {
+		return "gpt-5.1-codex-max";
+	}
+
+	// 2. GPT-5.1 Codex Mini
 	if (
 		normalized.includes("gpt-5.1-codex-mini") ||
 		normalized.includes("gpt 5.1 codex mini")
@@ -46,7 +54,7 @@ export function normalizeModel(model: string | undefined): string {
 		return "gpt-5.1-codex-mini";
 	}
 
-	// 2. Legacy Codex Mini
+	// 3. Legacy Codex Mini
 	if (
 		normalized.includes("codex-mini-latest") ||
 		normalized.includes("gpt-5-codex-mini") ||
@@ -129,7 +137,7 @@ export function getReasoningConfig(
 			normalizedOriginal.includes("mini"));
 
 	// Default based on model type (Codex CLI defaults)
-	const defaultEffort: "minimal" | "low" | "medium" | "high" = isCodexMini
+	const defaultEffort: "minimal" | "low" | "medium" | "high" | "xhigh" = isCodexMini
 		? "medium"
 		: isLightweight
 			? "minimal"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,7 +27,7 @@ export interface UserConfig {
  * Configuration options for reasoning and text settings
  */
 export interface ConfigOptions {
-	reasoningEffort?: "minimal" | "low" | "medium" | "high";
+	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "concise" | "detailed";
 	textVerbosity?: "low" | "medium" | "high";
 	include?: string[];
@@ -37,7 +37,7 @@ export interface ConfigOptions {
  * Reasoning configuration for requests
  */
 export interface ReasoningConfig {
-	effort: "minimal" | "low" | "medium" | "high";
+	effort: "minimal" | "low" | "medium" | "high" | "xhigh";
 	summary: "auto" | "concise" | "detailed";
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -570,7 +570,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
       "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oslojs/binary": "1.0.0"
       }
@@ -579,15 +578,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
       "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@oslojs/crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oslojs/asn1": "1.0.0",
         "@oslojs/binary": "1.0.0"
@@ -597,15 +594,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@oslojs/jwt": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
       "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oslojs/encoding": "0.4.1"
       }
@@ -614,8 +609,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
       "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -975,6 +969,7 @@
       "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -1643,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.4.tgz",
       "integrity": "sha512-YG/fo7zlU3KwrBL5vDpWKisLYiM+nVstBQqfr7gCPbSYURnNEP9BDxEMz8KfsDR9JX0lJWDRNc6nXX31v7ZEyg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1982,6 +1978,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2294,6 +2291,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2336,6 +2334,7 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2441,6 +2440,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -1065,4 +1065,60 @@ describe('Request Transformer Module', () => {
 			});
 		});
 	});
+
+	describe('Codex Max Support', () => {
+		describe('normalizeModel', () => {
+			it('should normalize gpt-5.1-codex-max', async () => {
+				expect(normalizeModel('gpt-5.1-codex-max')).toBe('gpt-5.1-codex-max');
+			});
+
+			it('should normalize gpt-5.1-codex-max variants', async () => {
+				expect(normalizeModel('gpt-5.1-codex-max-low')).toBe('gpt-5.1-codex-max');
+				expect(normalizeModel('gpt-5.1-codex-max-medium')).toBe('gpt-5.1-codex-max');
+				expect(normalizeModel('gpt-5.1-codex-max-high')).toBe('gpt-5.1-codex-max');
+				expect(normalizeModel('gpt-5.1-codex-max-xhigh')).toBe('gpt-5.1-codex-max');
+			});
+
+			it('should normalize pattern matched max variants', async () => {
+				expect(normalizeModel('gpt 5.1 codex max')).toBe('gpt-5.1-codex-max');
+				expect(normalizeModel('GPT-5.1-CODEX-MAX')).toBe('gpt-5.1-codex-max');
+			});
+		});
+
+		describe('transformRequestBody', () => {
+			const codexInstructions = 'Test Codex Instructions';
+
+			it('should handle gpt-5.1-codex-max with xhigh effort', async () => {
+				const body: RequestBody = {
+					model: 'gpt-5.1-codex-max',
+					input: [],
+				};
+				const userConfig: UserConfig = {
+					global: {},
+					models: {
+						'gpt-5.1-codex-max': {
+							options: { reasoningEffort: 'xhigh' }
+						}
+					}
+				};
+
+				const result = await transformRequestBody(body, codexInstructions, userConfig);
+
+				expect(result.model).toBe('gpt-5.1-codex-max');
+				expect(result.reasoning?.effort).toBe('xhigh');
+			});
+
+			it('should default to medium effort for gpt-5.1-codex-max', async () => {
+				const body: RequestBody = {
+					model: 'gpt-5.1-codex-max',
+					input: [],
+				};
+
+				const result = await transformRequestBody(body, codexInstructions);
+
+				expect(result.model).toBe('gpt-5.1-codex-max');
+				expect(result.reasoning?.effort).toBe('medium');
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Summary
This PR adds full support for the new `gpt-5.1-codex-max` model family and the `xhigh` reasoning effort level.

## Changes
- Added `gpt-5.1-codex-max` to model normalization and mapping.
- Added support for `xhigh` reasoning effort (supported by the max model).
- Updated `config/full-opencode.json` to include 4 new verified model variants:
  - `gpt-5.1-codex-max-low`
  - `gpt-5.1-codex-max-medium`
  - `gpt-5.1-codex-max-high`
  - `gpt-5.1-codex-max-xhigh`
- Updated documentation (README, config docs) to reflect these additions.
- Added comprehensive tests for the new model and reasoning level.

## verification
- Added new unit tests in `test/request-transformer.test.ts`.
- Verified `npm test` passes (173 tests passed).