### PR TITLE
fix: map 404 to 429 to trigger opencode retries

### DIFF
--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -270,9 +270,13 @@ export async function handleErrorResponse(
 
 	const headers = new Headers(response.headers);
 	headers.set("content-type", "application/json; charset=utf-8");
+	// Map 404 to 429 to trigger opencode retries
+	const status = response.status === 404 ? 429 : response.status;
+	const statusText = response.status === 404 ? "Too Many Requests" : response.statusText;
+
 	return new Response(enriched, {
-		status: response.status,
-		statusText: response.statusText,
+		status,
+		statusText,
 		headers,
 	});
 }


### PR DESCRIPTION
This fixes https://github.com/numman-ali/opencode-openai-codex-auth/issues/50. I'm just unsure on how to handle *actual* 404 errors.