### PR TITLE
Prevent orphaned tool outputs from triggering Codex 400s

### DIFF
--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -443,8 +443,8 @@ export async function transformRequestBody(
 		}
 
 		// Filter orphaned function_call_output items (where function_call was an item_reference that got filtered)
-		// Keep matched pairs for compaction context
-		if (!body.tools && body.input) {
+		// Keep matched pairs for compaction context but drop unmatched outputs to avoid Codex API 400 errors
+		if (body.input) {
 			// Collect all call_ids from function_call items
 			const functionCallIds = new Set(
 				body.input
@@ -454,7 +454,10 @@ export async function transformRequestBody(
 			// Only filter function_call_output items that don't have a matching function_call
 			body.input = body.input.filter((item) => {
 				if (item.type === "function_call_output") {
-					return functionCallIds.has(item.call_id);
+					return (
+						typeof item.call_id === "string" &&
+						functionCallIds.has(item.call_id)
+					);
 				}
 				return true;
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "4.0.0",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-openai-codex-auth",
-      "version": "4.0.0",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",


### PR DESCRIPTION
Changes:
  - Walk every request’s input, collect valid function_call.call_ids, and drop only those function_call_output entries whose call_id is missing, non-string, or unmatched—regardless of whether tools are configured—
    so Codex never receives phantom tool results while legitimate call/output pairs stay intact for compaction context (lib/request/request-transformer.ts).
  - Added tests that mimic tool-enabled compaction/summary flows to confirm unmatched outputs are removed and matched pairs survive (test/request-transformer.test.ts).
  - Synced package-lock.json metadata with the current package version.

  Testing:
  - Manual check: prompted Opencode to write a file (exercising the write tool) and verified the tool call/output round-trip completed without the No tool call found… 400.

