### PR TITLE
feat: v4.1.1 - Combined PRs #62, #63, #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project are documented here. Dates use the ISO format (YYYY-MM-DD).
 
+## [4.1.1] - 2025-12-17
+
+**Minor release**: "none" reasoning effort support, orphaned function_call_output fix, and HTML version update.
+
+### Added
+- **"none" reasoning effort support**: GPT-5.1 and GPT-5.2 support `reasoning_effort: "none"` which disables the reasoning phase entirely. This can result in faster responses when reasoning is not needed.
+  - `gpt-5.2-none` - GPT-5.2 with reasoning disabled
+  - `gpt-5.1-none` - GPT-5.1 with reasoning disabled
+- **4 new unit tests** for "none" reasoning behavior (now 197 total unit tests).
+
+### Fixed
+- **Orphaned function_call_output 400 errors**: Fixed API errors when conversation history contains `item_reference` pointing to stored function calls. Previously, orphaned `function_call_output` items were only filtered when `!body.tools`. Now always handles orphans regardless of tools presence, and converts them to assistant messages to preserve context while avoiding API errors.
+- **OAuth HTML version display**: Updated version in oauth-success.html from 1.0.4 to 4.1.0.
+
+### Technical Details
+- `getReasoningConfig()` now detects GPT-5.1 general purpose models (not Codex variants) and allows "none" to pass through.
+- GPT-5.2 inherits "none" support as it's newer than GPT-5.1.
+- Codex variants (gpt-5.1-codex, gpt-5.1-codex-max, gpt-5.1-codex-mini) do NOT support "none":
+  - Codex and Codex Max: "none" auto-converts to "low"
+  - Codex Mini: "none" auto-converts to "medium" (as before)
+- Documentation updated with complete reasoning effort support matrix per model family.
+
+### References
+- **OpenAI API docs** (`platform.openai.com/docs/api-reference/chat/create`): "gpt-5.1 defaults to none, which does not perform reasoning. The supported reasoning values for gpt-5.1 are none, low, medium, and high."
+- **Codex CLI** (`codex-rs/protocol/src/openai_models.rs`): `ReasoningEffort` enum includes `None` variant with `#[serde(rename_all = "lowercase")]` serialization to `"none"`.
+- **Codex CLI** (`codex-rs/core/src/client.rs`): Request builder passes `ReasoningEffort::None` through to API without validation/rejection.
+- **Codex CLI** (`docs/config.md`): Documents `model_reasoning_effort = "none"` as valid config option.
+
+### Notes
+- This plugin defaults to "medium" for better coding assistance; users must explicitly set "none" if desired.
+
 ## [4.1.0] - 2025-12-11
 
 **Feature release**: GPT 5.2 model support and image input capabilities.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
 ## Features
 
 - ✅ **ChatGPT Plus/Pro OAuth authentication** - Use your existing subscription
-- ✅ **16 pre-configured model variants** - GPT 5.2, GPT 5.1, GPT 5.1 Codex, GPT 5.1 Codex Max, and GPT 5.1 Codex Mini presets for all reasoning levels
+- ✅ **18 pre-configured model variants** - GPT 5.2, GPT 5.1, GPT 5.1 Codex, GPT 5.1 Codex Max, and GPT 5.1 Codex Mini presets for all reasoning levels
 - ✅ **GPT 5.2 support** - Latest model with `low/medium/high/xhigh` reasoning levels
 - ✅ **Full image input support** - All models configured with multimodal capabilities for reading screenshots, diagrams, and images
 - ⚠️ **GPT 5.1+ only** - Older GPT 5.0 models are deprecated and may not work reliably
@@ -62,7 +62,7 @@ Follow me on [X @nummanthinks](https://x.com/nummanthinks) for future updates an
 #### Recommended: Pin the Version
 
 ```json
-"plugin": ["opencode-openai-codex-auth@4.1.0"]
+"plugin": ["opencode-openai-codex-auth@4.1.1"]
 ```
 
 **Why pin versions?** OpenCode uses Bun's lockfile which pins resolved versions. If you use `"opencode-openai-codex-auth"` without a version, it resolves to "latest" once and **never updates** even when new versions are published.
@@ -76,7 +76,7 @@ Simply change the version in your config and restart OpenCode:
 "plugin": ["opencode-openai-codex-auth@3.3.0"]
 
 // To:
-"plugin": ["opencode-openai-codex-auth@4.1.0"]
+"plugin": ["opencode-openai-codex-auth@4.1.1"]
 ```
 
 OpenCode will detect the version mismatch and install the new version automatically.
@@ -107,12 +107,12 @@ Check [releases](https://github.com/numman-ali/opencode-openai-codex-auth/releas
 
 1. **Copy the full configuration** from [`config/full-opencode.json`](./config/full-opencode.json) to your opencode config file.
 
-   The config includes 16 models with image input support. Here's a condensed example showing the structure:
+   The config includes 18 models with image input support. Here's a condensed example showing the structure:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-openai-codex-auth@4.1.0"],
+  "plugin": ["opencode-openai-codex-auth@4.1.1"],
   "provider": {
     "openai": {
       "options": {
@@ -159,12 +159,12 @@ Check [releases](https://github.com/numman-ali/opencode-openai-codex-auth/releas
    **Global config**: `~/.config/opencode/opencode.json`
    **Project config**: `<project>/.opencode.json`
 
-   This gives you 16 model variants with different reasoning levels:
-   - **gpt-5.2** (low/medium/high/xhigh) - Latest GPT 5.2 model with full reasoning support
+   This gives you 18 model variants with different reasoning levels:
+   - **gpt-5.2** (none/low/medium/high/xhigh) - Latest GPT 5.2 model with full reasoning support
    - **gpt-5.1-codex-max** (low/medium/high/xhigh) - Codex Max presets
    - **gpt-5.1-codex** (low/medium/high) - Codex model presets
    - **gpt-5.1-codex-mini** (medium/high) - Codex mini tier presets
-   - **gpt-5.1** (low/medium/high) - General-purpose reasoning presets
+   - **gpt-5.1** (none/low/medium/high) - General-purpose reasoning presets
 
    All appear in the opencode model selector as "GPT 5.1 Codex Low (OAuth)", "GPT 5.1 High (OAuth)", etc.
 
@@ -305,7 +305,7 @@ These defaults match the official Codex CLI behavior and can be customized (see 
 ### ⚠️ REQUIRED: Use Pre-Configured File
 
 **YOU MUST use [`config/full-opencode.json`](./config/full-opencode.json)** - this is the only officially supported configuration:
-- 16 pre-configured model variants (GPT 5.2, GPT 5.1, Codex, Codex Max, Codex Mini)
+- 18 pre-configured model variants (GPT 5.2, GPT 5.1, Codex, Codex Max, Codex Mini)
 - Image input support enabled for all models
 - Optimal configuration for each reasoning level
 - All variants visible in the opencode model selector
@@ -323,18 +323,19 @@ If you want to customize settings yourself, you can configure options at provide
 
 ⚠️ **Important**: Families have different supported values.
 
-| Setting | GPT-5.2 Values | GPT-5 / GPT-5.1 Values | GPT-5.1-Codex Values | GPT-5.1-Codex-Max Values | Plugin Default |
-|---------|---------------|----------------------|----------------------|---------------------------|----------------|
-| `reasoningEffort` | `low`, `medium`, `high`, `xhigh` | `minimal`, `low`, `medium`, `high` | `low`, `medium`, `high` | `none`, `low`, `medium`, `high`, `xhigh` | `medium` (global), `high` for Codex Max/5.2 |
+| Setting | GPT-5.2 Values | GPT-5.1 Values | GPT-5.1-Codex Values | GPT-5.1-Codex-Max Values | Plugin Default |
+|---------|---------------|----------------|----------------------|---------------------------|----------------|
+| `reasoningEffort` | `none`, `low`, `medium`, `high`, `xhigh` | `none`, `low`, `medium`, `high` | `low`, `medium`, `high` | `low`, `medium`, `high`, `xhigh` | `medium` (global), `high` for Codex Max/5.2 |
 | `reasoningSummary` | `auto`, `concise`, `detailed` | `auto`, `concise`, `detailed` | `auto`, `concise`, `detailed` | `auto`, `concise`, `detailed`, `off`, `on` | `auto` |
 | `textVerbosity` | `low`, `medium`, `high` | `low`, `medium`, `high` | `medium` or `high` | `medium` or `high` | `medium` |
 | `include` | Array of strings | Array of strings | Array of strings | Array of strings | `["reasoning.encrypted_content"]` |
 
 > **Notes**:
-> - GPT 5.2 supports `xhigh` reasoning like Codex Max.
+> - GPT 5.2 and GPT 5.1 (general purpose) support `none` reasoning per OpenAI API docs.
+> - `none` is NOT supported for Codex variants - auto-converts to `low` for Codex/Codex Max, or `medium` for Codex Mini.
+> - GPT 5.2 and Codex Max support `xhigh` reasoning.
 > - `minimal` effort is auto-normalized to `low` for Codex models.
 > - Codex Mini clamps to `medium`/`high`; `xhigh` downgrades to `high`.
-> - Codex Max supports `none`/`xhigh` plus extended reasoning options while keeping the same 272k context / 128k output limits.
 > - All models have `modalities.input: ["text", "image"]` enabled for multimodal support.
 
 #### Global Configuration Example
@@ -344,7 +345,7 @@ Apply settings to all models:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-openai-codex-auth@4.1.0"],
+  "plugin": ["opencode-openai-codex-auth@4.1.1"],
   "model": "openai/gpt-5-codex",
   "provider": {
     "openai": {
@@ -364,7 +365,7 @@ Create your own named variants in the model selector:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-openai-codex-auth@4.1.0"],
+  "plugin": ["opencode-openai-codex-auth@4.1.1"],
   "provider": {
     "openai": {
       "models": {

--- a/config/full-opencode.json
+++ b/config/full-opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "opencode-openai-codex-auth@4.1.0"
+    "opencode-openai-codex-auth@4.1.1"
   ],
   "provider": {
     "openai": {
@@ -15,6 +15,31 @@
         "store": false
       },
       "models": {
+        "gpt-5.2-none": {
+          "name": "GPT 5.2 None (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "none",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.2-low": {
           "name": "GPT 5.2 Low (OAuth)",
           "limit": {
@@ -22,8 +47,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "low",
@@ -42,8 +72,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "medium",
@@ -62,8 +97,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "high",
@@ -82,8 +122,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "xhigh",
@@ -102,8 +147,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "low",
@@ -122,8 +172,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "medium",
@@ -142,8 +197,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "high",
@@ -162,8 +222,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "xhigh",
@@ -182,8 +247,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "low",
@@ -202,8 +272,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "medium",
@@ -222,8 +297,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "high",
@@ -242,8 +322,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "medium",
@@ -262,12 +347,42 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "high",
             "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.1-none": {
+          "name": "GPT 5.1 None (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "none",
+            "reasoningSummary": "auto",
             "textVerbosity": "medium",
             "include": [
               "reasoning.encrypted_content"
@@ -282,8 +397,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "low",
@@ -302,8 +422,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "medium",
@@ -322,8 +447,13 @@
             "output": 128000
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           },
           "options": {
             "reasoningEffort": "high",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,28 +46,35 @@ Complete reference for configuring the OpenCode OpenAI Codex Auth Plugin.
 
 Controls computational effort for reasoning.
 
-**GPT-5 Values:**
-- `minimal` - Fastest, least reasoning
+**GPT-5.2 Values** (per OpenAI API docs and Codex CLI `ReasoningEffort` enum):
+- `none` - No dedicated reasoning phase (disables reasoning)
+- `low` - Light reasoning
+- `medium` - Balanced (default)
+- `high` - Deep reasoning
+- `xhigh` - Extra depth for long-horizon tasks
+
+**GPT-5.1 Values** (per OpenAI API docs and Codex CLI `ReasoningEffort` enum):
+- `none` - No dedicated reasoning phase (disables reasoning)
 - `low` - Light reasoning
 - `medium` - Balanced (default)
 - `high` - Deep reasoning
 
-**GPT-5-Codex Values:**
+**GPT-5.1-Codex / GPT-5.1-Codex-Max Values:**
 - `low` - Fastest for code
 - `medium` - Balanced (default)
 - `high` - Maximum code quality
+- `xhigh` - Extra depth (Codex Max only)
 
-**GPT-5.1-Codex-Max Values:**
-- `none` - No dedicated reasoning phase
-- `low` - Light reasoning
-- `medium` - Balanced
-- `high` - Deep reasoning (default for this family)
-- `xhigh` - Extra depth for long-horizon tasks
+**GPT-5.1-Codex-Mini Values:**
+- `medium` - Balanced (default)
+- `high` - Maximum code quality
 
 **Notes**:
+- `none` is supported for GPT-5.2 and GPT-5.1 (general purpose) per OpenAI API documentation
+- `none` is NOT supported for Codex variants - it auto-converts to `low` for Codex or `medium` for Codex Mini
 - `minimal` auto-converts to `low` for Codex models
-- `gpt-5-codex-mini*` and `gpt-5.1-codex-mini*` only support `medium` or `high`; lower settings are clamped to `medium` and `xhigh` downgrades to `high`
-- Codex Max supports `none` and `xhigh` and defaults to `high` when not specified
+- `xhigh` is only supported for GPT-5.2 and GPT-5.1-Codex-Max; other models downgrade to `high`
+- Codex Mini only supports `medium` or `high`; lower settings clamp to `medium`
 
 **Example:**
 ```json

--- a/lib/oauth-success.html
+++ b/lib/oauth-success.html
@@ -548,7 +548,7 @@
                 <div class="terminal-button red"></div>
                 <div class="terminal-button yellow"></div>
                 <div class="terminal-button green"></div>
-                <div class="terminal-title">opencode-openai-codex-auth@1.0.4 — OAuth Authentication</div>
+                <div class="terminal-title">opencode-openai-codex-auth@4.1.0 — OAuth Authentication</div>
             </div>
 
             <div class="status-box">

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -30,9 +30,10 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.1-codex-max-xhigh": "gpt-5.1-codex-max",
 
 	// ============================================================================
-	// GPT-5.2 Models (same reasoning support as Codex Max: low/medium/high/xhigh)
+	// GPT-5.2 Models (supports none/low/medium/high/xhigh per OpenAI API docs)
 	// ============================================================================
 	"gpt-5.2": "gpt-5.2",
+	"gpt-5.2-none": "gpt-5.2",
 	"gpt-5.2-low": "gpt-5.2",
 	"gpt-5.2-medium": "gpt-5.2",
 	"gpt-5.2-high": "gpt-5.2",
@@ -46,9 +47,10 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.1-codex-mini-high": "gpt-5.1-codex-mini",
 
 	// ============================================================================
-	// GPT-5.1 General Purpose Models
+	// GPT-5.1 General Purpose Models (supports none/low/medium/high per OpenAI API docs)
 	// ============================================================================
 	"gpt-5.1": "gpt-5.1",
+	"gpt-5.1-none": "gpt-5.1",
 	"gpt-5.1-low": "gpt-5.1",
 	"gpt-5.1-medium": "gpt-5.1",
 	"gpt-5.1-high": "gpt-5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "OpenAI ChatGPT (Codex backend) OAuth auth plugin for opencode - use your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/test-all-models.sh
+++ b/scripts/test-all-models.sh
@@ -174,7 +174,8 @@ test_model "gpt-5.1-codex-max-medium" "gpt-5.1-codex-max"   "codex-max"  "medium
 test_model "gpt-5.1-codex-max-high"   "gpt-5.1-codex-max"   "codex-max"  "high"    "detailed" "medium"
 test_model "gpt-5.1-codex-max-xhigh"  "gpt-5.1-codex-max"   "codex-max"  "xhigh"   "detailed" "medium"
 
-# GPT 5.2 presets (same reasoning support as Codex Max: low/medium/high/xhigh)
+# GPT 5.2 presets (supports none/low/medium/high/xhigh per OpenAI API docs)
+test_model "gpt-5.2-none"   "gpt-5.2"   "gpt-5.2"  "none"    "auto"     "medium"
 test_model "gpt-5.2-low"    "gpt-5.2"   "gpt-5.2"  "low"     "auto"     "medium"
 test_model "gpt-5.2-medium" "gpt-5.2"   "gpt-5.2"  "medium"  "auto"     "medium"
 test_model "gpt-5.2-high"   "gpt-5.2"   "gpt-5.2"  "high"    "detailed" "medium"
@@ -184,7 +185,8 @@ test_model "gpt-5.2-xhigh"  "gpt-5.2"   "gpt-5.2"  "xhigh"   "detailed" "medium"
 test_model "gpt-5.1-codex-mini-medium" "gpt-5.1-codex-mini" "codex"      "medium"  "auto"     "medium"
 test_model "gpt-5.1-codex-mini-high"   "gpt-5.1-codex-mini" "codex"      "high"    "detailed" "medium"
 
-# GPT 5.1 general-purpose presets
+# GPT 5.1 general-purpose presets (supports none/low/medium/high per OpenAI API docs)
+test_model "gpt-5.1-none"          "gpt-5.1"       "gpt-5.1"    "none"    "auto"     "medium"
 test_model "gpt-5.1-low"           "gpt-5.1"       "gpt-5.1"    "low"     "auto"     "low"
 test_model "gpt-5.1-medium"        "gpt-5.1"       "gpt-5.1"    "medium"  "auto"     "medium"
 test_model "gpt-5.1-high"          "gpt-5.1"       "gpt-5.1"    "high"    "detailed" "high"


### PR DESCRIPTION
## Summary

This release combines fixes and features from three community PRs into a single v4.1.1 release:

- **PR #62** (@ben-vargas): Add "none" reasoning effort support for GPT-5.2 and GPT-5.1
- **PR #63** (@code-yeongyu): Fix orphaned function_call_output 400 errors
- **PR #64** (@kanemontreuil): Update OAuth HTML version display

## Changes

### Added
- **"none" reasoning effort support**: GPT-5.1 and GPT-5.2 general purpose models now support `reasoning_effort: "none"` which disables the reasoning phase entirely for faster responses
  - `gpt-5.2-none` - GPT-5.2 with reasoning disabled
  - `gpt-5.1-none` - GPT-5.1 with reasoning disabled
- **Model mappings**: Added `gpt-5.2-none` and `gpt-5.1-none` to model-map.ts
- **Model presets**: Added none presets to opencode.json configs (now 18 total models)
- **4 new unit tests** for "none" reasoning behavior (197 total tests)

### Fixed
- **Orphaned function_call_output 400 errors**: Fixed API errors when conversation history contains `item_reference` pointing to stored function calls
  - Previously, orphaned `function_call_output` items were only filtered when `!body.tools`
  - Now always handles orphans regardless of tools presence
  - **Converts orphans to assistant messages** instead of removing them, preserving context while avoiding API errors
- **OAuth HTML version display**: Updated version in oauth-success.html from 1.0.4 to 4.1.0

### Technical Details
- `getReasoningConfig()` now detects GPT-5.1 general purpose models (not Codex variants) and allows "none" to pass through
- GPT-5.2 inherits "none" support as it's newer than GPT-5.1
- Codex variants do NOT support "none":
  - Codex and Codex Max: "none" auto-converts to "low"
  - Codex Mini: "none" auto-converts to "medium"

### Documentation Updated
- README.md: Updated to 18 models, updated reasoning effort table, version references
- docs/configuration.md: Updated reasoning effort documentation with complete support matrix
- scripts/test-all-models.sh: Added gpt-5.2-none and gpt-5.1-none tests
- CHANGELOG.md: Combined release notes for all 3 PRs

## Reasoning Effort Support Matrix

| Model | `none` | `low` | `medium` | `high` | `xhigh` |
|-------|--------|-------|----------|--------|---------|
| GPT-5.2 | ✅ | ✅ | ✅ | ✅ | ✅ |
| GPT-5.1 | ✅ | ✅ | ✅ | ✅ | ❌ |
| GPT-5.1-Codex | ❌→low | ✅ | ✅ | ✅ | ❌ |
| GPT-5.1-Codex-Max | ❌→low | ✅ | ✅ | ✅ | ✅ |
| GPT-5.1-Codex-Mini | ❌→medium | ❌→medium | ✅ | ✅ | ❌→high |

## Test Plan

- [x] TypeScript type checking passes
- [x] All 197 unit tests pass (was 193, added 4 new tests)
- [x] Build succeeds
- [ ] Manual testing with opencode using local dist

## Related PRs

Supersedes:
- #62 - feat: Add "none" reasoning effort support for GPT-5.2 and GPT-5.1
- #63 - fix: filter orphaned function_call_output even when tools present
- #64 - Update OAuth Authentication version in HTML

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)