### PR TITLE
Add support for 5.2 Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides coding guidance for AI agents (including Claude Code, Codex, 
 
 ## Overview
 
-This is an **opencode plugin** that enables OAuth authentication with OpenAI's ChatGPT Plus/Pro Codex backend. It allows users to access `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, and `gpt-5.1` models through their ChatGPT subscription instead of using OpenAI Platform API credits. Legacy GPT-5.0 models are automatically normalized to their GPT-5.1 equivalents.
+This is an **opencode plugin** that enables OAuth authentication with OpenAI's ChatGPT Plus/Pro Codex backend. It allows users to access `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, and `gpt-5.1` models through their ChatGPT subscription instead of using OpenAI Platform API credits. Legacy GPT-5.0 models are automatically normalized to their GPT-5.1 equivalents.
 
 **Key architecture principle**: 7-step fetch flow that intercepts opencode's OpenAI SDK requests, transforms them for the ChatGPT backend API, and handles OAuth token management.
 
@@ -98,18 +98,21 @@ The main entry point orchestrates a **7-step fetch flow**:
 - Plugin defaults: `reasoningEffort: "medium"`, `reasoningSummary: "auto"`, `textVerbosity: "medium"`
 
 **4. Model Normalization** (GPT-5.0 → GPT-5.1 migration):
+- All `gpt-5.2-codex*` variants → `gpt-5.2-codex` (newest codex model, supports xhigh)
 - All `gpt-5.1-codex-max*` variants → `gpt-5.1-codex-max`
 - All `gpt-5.1-codex*` variants → `gpt-5.1-codex`
 - All `gpt-5.1-codex-mini*` variants → `gpt-5.1-codex-mini`
+- All `gpt-5.2` variants → `gpt-5.2`
 - All `gpt-5.1` variants → `gpt-5.1`
 - **Legacy mappings** (GPT-5.0 being phased out):
   - `gpt-5-codex*` variants → `gpt-5.1-codex`
   - `gpt-5-codex-mini*` or `codex-mini-latest` → `gpt-5.1-codex-mini`
   - `gpt-5*` variants (including `gpt-5-mini`, `gpt-5-nano`) → `gpt-5.1`
-- `minimal` effort auto-normalized to `low` for Codex families and clamped to `medium` (or `high` when requested) for Codex Mini
+- `minimal` effort auto-normalized to `low` for Codex families (including GPT-5.2 Codex) and clamped to `medium` (or `high` when requested) for Codex Mini
 
 **5. Model-Specific Prompt Selection**:
 - Different prompts for different model families (matching Codex CLI):
+  - `gpt-5.2-codex*` → `gpt-5.1-codex-max_prompt.md` (117 lines, frontend design guidelines - same as codex-max)
   - `gpt-5.1-codex-max*` → `gpt-5.1-codex-max_prompt.md` (117 lines, frontend design guidelines)
   - `gpt-5.1-codex*`, `codex-*` → `gpt_5_codex_prompt.md` (105 lines, coding focus)
   - `gpt-5.1*` → `gpt_5_1_prompt.md` (368 lines, full behavioral guidance)
@@ -118,7 +121,7 @@ The main entry point orchestrates a **7-step fetch flow**:
 **6. Codex Instructions Caching**:
 - Fetches from latest release tag (not main branch)
 - ETag-based HTTP conditional requests per model family
-- Separate cache files per family: `codex-max-instructions.md`, `codex-instructions.md`, `gpt-5.1-instructions.md`
+- Separate cache files per family: `gpt-5.2-codex-instructions.md`, `codex-max-instructions.md`, `codex-instructions.md`, `gpt-5.1-instructions.md`
 - Cache invalidation when release tag changes
 - Falls back to bundled version if GitHub unavailable
 

--- a/config/full-opencode.json
+++ b/config/full-opencode.json
@@ -15,6 +15,106 @@
         "store": false
       },
       "models": {
+        "gpt-5.2-codex-low": {
+          "name": "GPT 5.2 Codex Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.2-codex-medium": {
+          "name": "GPT 5.2 Codex Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.2-codex-high": {
+          "name": "GPT 5.2 Codex High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.2-codex-xhigh": {
+          "name": "GPT 5.2 Codex Extra High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.2-none": {
           "name": "GPT 5.2 None (OAuth)",
           "limit": {

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -17,13 +17,14 @@ const __dirname = dirname(__filename);
  * Model family type for prompt selection
  * Maps to different system prompts in the Codex CLI
  */
-export type ModelFamily = "codex-max" | "codex" | "gpt-5.2" | "gpt-5.1";
+export type ModelFamily = "gpt-5.2-codex" | "codex-max" | "codex" | "gpt-5.2" | "gpt-5.1";
 
 /**
  * Prompt file mapping for each model family
  * Based on codex-rs/core/src/model_family.rs logic
  */
 const PROMPT_FILES: Record<ModelFamily, string> = {
+	"gpt-5.2-codex": "gpt-5.1-codex-max_prompt.md", // Shares prompts with codex-max
 	"codex-max": "gpt-5.1-codex-max_prompt.md",
 	codex: "gpt_5_codex_prompt.md",
 	"gpt-5.2": "gpt-5.1-codex-max_prompt.md", // GPT 5.2 uses same prompts as codex-max
@@ -34,6 +35,7 @@ const PROMPT_FILES: Record<ModelFamily, string> = {
  * Cache file mapping for each model family
  */
 const CACHE_FILES: Record<ModelFamily, string> = {
+	"gpt-5.2-codex": "gpt-5.2-codex-instructions.md",
 	"codex-max": "codex-max-instructions.md",
 	codex: "codex-instructions.md",
 	"gpt-5.2": "gpt-5.2-instructions.md",
@@ -42,11 +44,15 @@ const CACHE_FILES: Record<ModelFamily, string> = {
 
 /**
  * Determine the model family based on the normalized model name
- * @param normalizedModel - The normalized model name (e.g., "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1")
+ * @param normalizedModel - The normalized model name (e.g., "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1")
  * @returns The model family for prompt selection
  */
 export function getModelFamily(normalizedModel: string): ModelFamily {
 	// Order matters - check more specific patterns first
+	// GPT-5.2 Codex is the newest codex model
+	if (normalizedModel.includes("gpt-5.2-codex") || normalizedModel.includes("gpt 5.2 codex")) {
+		return "gpt-5.2-codex";
+	}
 	if (normalizedModel.includes("codex-max")) {
 		return "codex-max";
 	}

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -13,8 +13,17 @@
  */
 export const MODEL_MAP: Record<string, string> = {
 // ============================================================================
-// GPT-5.1 Codex Models
+// GPT-5.2 Codex Models (low/medium/high/xhigh)
 // ============================================================================
+	"gpt-5.2-codex": "gpt-5.2-codex",
+	"gpt-5.2-codex-low": "gpt-5.2-codex",
+	"gpt-5.2-codex-medium": "gpt-5.2-codex",
+	"gpt-5.2-codex-high": "gpt-5.2-codex",
+	"gpt-5.2-codex-xhigh": "gpt-5.2-codex",
+
+	// ============================================================================
+	// GPT-5.1 Codex Models
+	// ============================================================================
 	"gpt-5.1-codex": "gpt-5.1-codex",
 	"gpt-5.1-codex-low": "gpt-5.1-codex",
 	"gpt-5.1-codex-medium": "gpt-5.1-codex",
@@ -30,7 +39,7 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.1-codex-max-xhigh": "gpt-5.1-codex-max",
 
 	// ============================================================================
-	// GPT-5.2 Models (supports none/low/medium/high/xhigh per OpenAI API docs)
+	// GPT-5.2 General Purpose Models (supports none/low/medium/high/xhigh per OpenAI API docs)
 	// ============================================================================
 	"gpt-5.2": "gpt-5.2",
 	"gpt-5.2-none": "gpt-5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-openai-codex-auth",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "OpenAI ChatGPT (Codex backend) OAuth auth plugin for opencode - use your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -3,6 +3,24 @@ import { getModelFamily } from "../lib/prompts/codex.js";
 
 describe("Codex Module", () => {
 	describe("getModelFamily", () => {
+		describe("GPT-5.2 Codex family", () => {
+			it("should return gpt-5.2-codex for gpt-5.2-codex", () => {
+				expect(getModelFamily("gpt-5.2-codex")).toBe("gpt-5.2-codex");
+			});
+
+			it("should return gpt-5.2-codex for gpt-5.2-codex-low", () => {
+				expect(getModelFamily("gpt-5.2-codex-low")).toBe("gpt-5.2-codex");
+			});
+
+			it("should return gpt-5.2-codex for gpt-5.2-codex-high", () => {
+				expect(getModelFamily("gpt-5.2-codex-high")).toBe("gpt-5.2-codex");
+			});
+
+			it("should return gpt-5.2-codex for gpt-5.2-codex-xhigh", () => {
+				expect(getModelFamily("gpt-5.2-codex-xhigh")).toBe("gpt-5.2-codex");
+			});
+		});
+
 		describe("Codex Max family", () => {
 			it("should return codex-max for gpt-5.1-codex-max", () => {
 				expect(getModelFamily("gpt-5.1-codex-max")).toBe("codex-max");
@@ -66,6 +84,11 @@ describe("Codex Module", () => {
 		});
 
 		describe("Priority order", () => {
+			it("should prioritize gpt-5.2-codex over gpt-5.2 general", () => {
+				// "gpt-5.2-codex" also contains the substring "gpt-5.2"
+				expect(getModelFamily("gpt-5.2-codex")).toBe("gpt-5.2-codex");
+			});
+
 			it("should prioritize codex-max over codex", () => {
 				// Model contains both "codex-max" and "codex"
 				expect(getModelFamily("gpt-5.1-codex-max")).toBe("codex-max");
@@ -74,6 +97,12 @@ describe("Codex Module", () => {
 			it("should prioritize codex over gpt-5.1", () => {
 				// Model contains both "codex" and potential gpt-5.1
 				expect(getModelFamily("gpt-5.1-codex")).toBe("codex");
+			});
+
+			it("should return gpt-5.2 for gpt-5.2 general (not codex)", () => {
+				// Model is gpt-5.2 but NOT codex
+				expect(getModelFamily("gpt-5.2")).toBe("gpt-5.2");
+				expect(getModelFamily("gpt-5.2-high")).toBe("gpt-5.2");
 			});
 		});
 	});

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -81,6 +81,15 @@ describe('Request Transformer Module', () => {
 				expect(normalizeModel('openai/gpt-5.1-codex-max-medium')).toBe('gpt-5.1-codex-max');
 			});
 
+			it('should normalize gpt-5.2 codex presets', async () => {
+				expect(normalizeModel('gpt-5.2-codex')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-low')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-medium')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-high')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-xhigh')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('openai/gpt-5.2-codex-high')).toBe('gpt-5.2-codex');
+			});
+
 			it('should normalize gpt-5.1 codex and mini slugs', async () => {
 				expect(normalizeModel('gpt-5.1-codex')).toBe('gpt-5.1-codex');
 				expect(normalizeModel('openai/gpt-5.1-codex')).toBe('gpt-5.1-codex');
@@ -837,6 +846,63 @@ describe('Request Transformer Module', () => {
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
 			expect(result.model).toBe('gpt-5.2');
 			expect(result.reasoning?.effort).toBe('none');
+		});
+
+		it('should default gpt-5.2-codex to high effort', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.2-codex',
+				input: [],
+			};
+			const result = await transformRequestBody(body, codexInstructions);
+			expect(result.model).toBe('gpt-5.2-codex');
+			expect(result.reasoning?.effort).toBe('high');
+		});
+
+		it('should preserve xhigh for gpt-5.2-codex when requested', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.2-codex-xhigh',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: {},
+				models: {
+					'gpt-5.2-codex-xhigh': {
+						options: { reasoningEffort: 'xhigh', reasoningSummary: 'detailed' },
+					},
+				},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.2-codex');
+			expect(result.reasoning?.effort).toBe('xhigh');
+			expect(result.reasoning?.summary).toBe('detailed');
+		});
+
+		it('should upgrade none to low for gpt-5.2-codex (codex does not support none)', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.2-codex',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: { reasoningEffort: 'none' },
+				models: {},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.2-codex');
+			expect(result.reasoning?.effort).toBe('low');
+		});
+
+		it('should normalize minimal to low for gpt-5.2-codex', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.2-codex',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: { reasoningEffort: 'minimal' },
+				models: {},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.2-codex');
+			expect(result.reasoning?.effort).toBe('low');
 		});
 
 		it('should preserve none for GPT-5.1 general purpose', async () => {


### PR DESCRIPTION
This PR adds support for 5.2 codex.
Tests run and the new model works locally. I have taken the same context window parameters from the older models (I am not sure if anything changed for 5.2 codex and whether these numbers are available yet).

Not sure what the contribution policy is, feel free to close if unwanted 😊