### PR TITLE
feat: add manual URL paste option for OAuth in remote environments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -301,6 +301,13 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									return { type: "failed" as const };
 								}
 
+								// Validate state parameter to prevent CSRF and authorization code substitution
+								if (!parsed.state || parsed.state !== state) {
+									console.error(
+										"[openai-codex-plugin] Invalid or missing state parameter in authorization response",
+									);
+									return { type: "failed" as const };
+								}
 								const tokens = await exchangeAuthorizationCode(
 									parsed.code,
 									pkce.verifier,


### PR DESCRIPTION
## Summary
- Adds a second OAuth login method **"ChatGPT Plus/Pro (Manual URL Paste)"** that allows users to manually paste the redirect URL after authentication

## Problem
The current OAuth flow relies on a localhost callback server, which doesn't work in:
- Remote servers (SSH)
- Containers/Docker
- WSL without localhost forwarding
- Any environment where the browser can't reach `localhost:1455`

## Solution
Added a new auth method using OpenCode's `method: "code"` which prompts users to paste the redirect URL manually. This uses the existing `parseAuthorizationInput()` function to extract the authorization code from the pasted URL.

Users now see three options when authenticating:
1. **ChatGPT Plus/Pro (Codex Subscription)** - Original automatic localhost callback
2. **ChatGPT Plus/Pro (Manual URL Paste)** - New manual flow for remote environments  
3. **Manually enter API Key** - Direct API key entry

## Testing
Tested successfully on a remote server where localhost callbacks were not accessible.