### PR TITLE
docs: Simplify cache clean command to prevent SIGTRAP on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ OpenCode will detect the version mismatch and install the new version automatica
 If you previously used an unpinned version, clear the cache:
 
 ```bash
-rm -rf ~/.cache/opencode/node_modules ~/.cache/opencode/bun.lock
+rm -rf ~/.cache/opencode
 ```
 
 Then restart OpenCode with a pinned version in your config.
@@ -113,7 +113,7 @@ If you’re using an AI agent (Codex/Claude/etc.) to install or update this plug
 cp <repo>/config/full-opencode.json ~/.config/opencode/opencode.json
 
 # 3) Refresh OpenCode plugin cache
-rm -rf ~/.cache/opencode/node_modules ~/.cache/opencode/bun.lock
+rm -rf ~/.cache/opencode
 
 # 4) Optional sanity check for GPT-5.2-Codex presets
 jq '.provider.openai.models | keys | map(select(startswith("gpt-5.2-codex")))' \


### PR DESCRIPTION
This PR updates the recommended OpenCode cache clean command from:
`rm -rf ~/.cache/opencode/node_modules ~/.cache/opencode/bun.lock`
to:
`rm -rf ~/.cache/opencode`

After upgrading to **opencode v1.0.198**, the old partial cache clean can lead to:
`'opencode' terminated by signal SIGTRAP (Trace or breakpoint trap)` on startup.
Clearing the entire `~/.cache/opencode` ensures a clean re-install and consistent boot.