### PR TITLE
fix: gracefully handle missing browser opener in headless environments

### DIFF
--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getBrowserOpener } from '../lib/auth/browser.js';
+import { getBrowserOpener, openBrowserUrl } from '../lib/auth/browser.js';
 import { PLATFORM_OPENERS } from '../lib/constants.js';
 
 describe('Browser Module', () => {
@@ -30,6 +30,31 @@ describe('Browser Module', () => {
 			Object.defineProperty(process, 'platform', { value: 'freebsd' });
 			expect(getBrowserOpener()).toBe(PLATFORM_OPENERS.linux);
 			Object.defineProperty(process, 'platform', { value: originalPlatform });
+		});
+	});
+
+	describe('openBrowserUrl', () => {
+		it('should not throw when browser opener command does not exist', () => {
+			// Temporarily set platform to use a non-existent command
+			const originalPlatform = process.platform;
+			const originalPath = process.env.PATH;
+
+			// Clear PATH to ensure no opener command is found
+			process.env.PATH = '';
+			Object.defineProperty(process, 'platform', { value: 'linux' });
+
+			// Should not throw even when xdg-open doesn't exist
+			expect(() => openBrowserUrl('https://example.com')).not.toThrow();
+
+			// Restore
+			process.env.PATH = originalPath;
+			Object.defineProperty(process, 'platform', { value: originalPlatform });
+		});
+
+		it('should handle valid URL without throwing', () => {
+			// This test verifies the function doesn't throw for valid input
+			// The actual browser opening is not tested as it would open a real browser
+			expect(() => openBrowserUrl('https://example.com')).not.toThrow();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add `commandExists()` check before attempting to spawn browser opener
- Prevents crash when `xdg-open` is not installed (Docker, WSL, CI, etc.)
- The URL is still printed, so users can manually open it in their browser
- Added tests for graceful handling when command is missing

## Changes

| File | Description |
|------|-------------|
| `lib/auth/browser.ts` | Added `commandExists()` helper that uses `which`/`where` to check if command exists before spawning |
| `test/browser.test.ts` | Added 2 tests to verify graceful handling when opener command is missing |

## Test Results

All 211 tests pass:
```
 ✓ test/browser.test.ts (6 tests) 50ms
 Test Files  9 passed (9)
      Tests  211 passed (211)
```

## Test Plan

- [x] Existing tests pass
- [x] New tests added for missing command scenario
- [x] Manually verified fix works by clearing PATH and calling `openBrowserUrl()`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)