### PR TITLE
feat: add multi-account support with automatic rate limit rotation

### DIFF
--- a/lib/accounts/cli.ts
+++ b/lib/accounts/cli.ts
@@ -1,0 +1,14 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+export async function promptAddAnotherAccount(currentCount: number): Promise<boolean> {
+	const rl = createInterface({ input: stdin, output: stdout });
+	try {
+		const answer = await rl.question(
+			`\nYou have ${currentCount} account(s). Add another? [y/N]: `,
+		);
+		return answer.toLowerCase().startsWith("y");
+	} finally {
+		rl.close();
+	}
+}

--- a/lib/accounts/manager.ts
+++ b/lib/accounts/manager.ts
@@ -1,0 +1,283 @@
+import type {
+	ManagedAccount,
+	AccountStorage,
+	OAuthAuthDetails,
+} from "../types.js";
+import { saveAccounts } from "./storage.js";
+import { logDebug } from "../logger.js";
+
+const ACCOUNT_SEPARATOR = "||";
+const FIELD_SEPARATOR = "|";
+
+function isRateLimited(account: ManagedAccount): boolean {
+	return (
+		account.rateLimitResetTime !== undefined &&
+		Date.now() < account.rateLimitResetTime
+	);
+}
+
+function clearExpiredRateLimit(account: ManagedAccount): void {
+	if (
+		account.rateLimitResetTime !== undefined &&
+		Date.now() >= account.rateLimitResetTime
+	) {
+		account.rateLimitResetTime = undefined;
+	}
+}
+
+export function parseMultiAccountRefresh(refresh: string): ManagedAccount[] {
+	if (!refresh) {
+		return [];
+	}
+
+	const accountStrings = refresh.split(ACCOUNT_SEPARATOR).filter((s) => s.trim());
+
+	if (accountStrings.length === 0) {
+		return [];
+	}
+
+	return accountStrings.map((str, index) => {
+		const [refreshToken = "", chatgptAccountId = ""] = str.split(FIELD_SEPARATOR);
+		return {
+			index,
+			refreshToken,
+			chatgptAccountId,
+			lastUsed: 0,
+		};
+	});
+}
+
+export function formatMultiAccountRefresh(accounts: ManagedAccount[]): string {
+	return accounts
+		.map((acc) => `${acc.refreshToken}${FIELD_SEPARATOR}${acc.chatgptAccountId}`)
+		.filter((s) => s.trim())
+		.join(ACCOUNT_SEPARATOR);
+}
+
+export class AccountManager {
+	private accounts: ManagedAccount[] = [];
+	private currentIndex = 0;
+	private currentAccountIndex = -1;
+
+	constructor(auth: OAuthAuthDetails, storedAccounts?: AccountStorage | null) {
+		if (storedAccounts && storedAccounts.accounts.length > 0) {
+			const activeIndex =
+				typeof storedAccounts.activeIndex === "number" &&
+				storedAccounts.activeIndex >= 0 &&
+				storedAccounts.activeIndex < storedAccounts.accounts.length
+					? storedAccounts.activeIndex
+					: 0;
+
+			this.currentAccountIndex = activeIndex;
+			this.currentIndex = activeIndex;
+
+			this.accounts = storedAccounts.accounts.map((acc, index) => ({
+				index,
+				refreshToken: acc.refreshToken,
+				chatgptAccountId: acc.chatgptAccountId,
+				accessToken: index === activeIndex ? auth.access : undefined,
+				expiresAt: index === activeIndex ? auth.expires : undefined,
+				rateLimitResetTime: acc.rateLimitResetTime,
+				lastUsed: acc.lastUsed,
+				email: acc.email,
+				lastSwitchReason: acc.lastSwitchReason,
+			}));
+
+			logDebug(`AccountManager initialized from storage with ${this.accounts.length} accounts, active: ${activeIndex}`);
+		} else {
+			const parsedAccounts = parseMultiAccountRefresh(auth.refresh);
+
+			this.currentAccountIndex = 0;
+			this.currentIndex = 0;
+
+			if (parsedAccounts.length > 0) {
+				this.accounts = parsedAccounts.map((acc, index) => ({
+					...acc,
+					index,
+					accessToken: index === 0 ? auth.access : undefined,
+					expiresAt: index === 0 ? auth.expires : undefined,
+				}));
+				logDebug(`AccountManager initialized from refresh string with ${this.accounts.length} accounts`);
+			} else {
+				const [refreshToken = "", chatgptAccountId = ""] = auth.refresh.split(FIELD_SEPARATOR);
+				this.accounts.push({
+					index: 0,
+					refreshToken,
+					chatgptAccountId,
+					accessToken: auth.access,
+					expiresAt: auth.expires,
+					lastUsed: 0,
+				});
+				logDebug("AccountManager initialized with single account");
+			}
+		}
+	}
+
+	async save(): Promise<void> {
+		const storage: AccountStorage = {
+			version: 1,
+			accounts: this.accounts.map((acc) => ({
+				refreshToken: acc.refreshToken,
+				chatgptAccountId: acc.chatgptAccountId,
+				email: acc.email,
+				addedAt: acc.lastUsed || Date.now(),
+				lastUsed: acc.lastUsed,
+				lastSwitchReason: acc.lastSwitchReason,
+				rateLimitResetTime: acc.rateLimitResetTime,
+			})),
+			activeIndex: Math.max(0, this.currentAccountIndex),
+		};
+
+		await saveAccounts(storage);
+	}
+
+	getCurrentAccount(): ManagedAccount | null {
+		if (
+			this.currentAccountIndex >= 0 &&
+			this.currentAccountIndex < this.accounts.length
+		) {
+			return this.accounts[this.currentAccountIndex] ?? null;
+		}
+		return null;
+	}
+
+	markSwitched(
+		account: ManagedAccount,
+		reason: "rate-limit" | "initial" | "rotation",
+	): void {
+		account.lastSwitchReason = reason;
+		this.currentAccountIndex = account.index;
+	}
+
+	getAccountCount(): number {
+		return this.accounts.length;
+	}
+
+	getCurrentOrNext(): ManagedAccount | null {
+		this.accounts.forEach(clearExpiredRateLimit);
+
+		const current = this.getCurrentAccount();
+		if (current && !isRateLimited(current)) {
+			current.lastUsed = Date.now();
+			logDebug(`Using current account ${current.index}/${this.accounts.length}`);
+			return current;
+		}
+
+		const next = this.getNext();
+		if (next) {
+			this.currentAccountIndex = next.index;
+			logDebug(`Rotated to account ${next.index}/${this.accounts.length}`);
+		} else {
+			logDebug("No available accounts (all rate limited)");
+		}
+		return next;
+	}
+
+	getNext(): ManagedAccount | null {
+		const available = this.accounts.filter((a) => !isRateLimited(a));
+
+		if (available.length === 0) {
+			return null;
+		}
+
+		const account = available[this.currentIndex % available.length];
+		if (!account) {
+			return null;
+		}
+
+		this.currentIndex++;
+		account.lastUsed = Date.now();
+		return account;
+	}
+
+	markRateLimited(account: ManagedAccount, retryAfterMs: number): void {
+		account.rateLimitResetTime = Date.now() + retryAfterMs;
+		logDebug(`Account ${account.index} rate limited, reset in ${Math.ceil(retryAfterMs / 1000)}s`);
+	}
+
+	updateAccount(
+		account: ManagedAccount,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): void {
+		account.accessToken = accessToken;
+		account.expiresAt = expiresAt;
+		if (refreshToken) {
+			account.refreshToken = refreshToken;
+		}
+		logDebug(`Account ${account.index} tokens refreshed, expires in ${Math.ceil((expiresAt - Date.now()) / 1000)}s`);
+	}
+
+	toAuthDetails(): OAuthAuthDetails {
+		const current = this.getCurrentAccount() || this.accounts[0];
+		if (!current) {
+			throw new Error("No accounts available");
+		}
+
+		return {
+			type: "oauth",
+			refresh: formatMultiAccountRefresh(this.accounts),
+			access: current.accessToken || "",
+			expires: current.expiresAt || 0,
+		};
+	}
+
+	addAccount(
+		refreshToken: string,
+		chatgptAccountId: string,
+		accessToken?: string,
+		expiresAt?: number,
+		email?: string,
+	): void {
+		this.accounts.push({
+			index: this.accounts.length,
+			refreshToken,
+			chatgptAccountId,
+			accessToken,
+			expiresAt,
+			lastUsed: 0,
+			email,
+		});
+	}
+
+	removeAccount(index: number): boolean {
+		if (index < 0 || index >= this.accounts.length) {
+			return false;
+		}
+		this.accounts.splice(index, 1);
+		this.accounts.forEach((acc, idx) => (acc.index = idx));
+		return true;
+	}
+
+	getAccounts(): ManagedAccount[] {
+		return [...this.accounts];
+	}
+
+	accountToAuth(account: ManagedAccount): OAuthAuthDetails {
+		return {
+			type: "oauth",
+			refresh: `${account.refreshToken}${FIELD_SEPARATOR}${account.chatgptAccountId}`,
+			access: account.accessToken ?? "",
+			expires: account.expiresAt ?? 0,
+		};
+	}
+
+	getMinWaitTime(): number {
+		const available = this.accounts.filter((a) => {
+			clearExpiredRateLimit(a);
+			return !isRateLimited(a);
+		});
+
+		if (available.length > 0) {
+			return 0;
+		}
+
+		const waitTimes = this.accounts
+			.map((a) => a.rateLimitResetTime)
+			.filter((t): t is number => t !== undefined)
+			.map((t) => Math.max(0, t - Date.now()));
+
+		return waitTimes.length > 0 ? Math.min(...waitTimes) : 0;
+	}
+}

--- a/lib/accounts/storage.ts
+++ b/lib/accounts/storage.ts
@@ -1,0 +1,130 @@
+/**
+ * Account storage for multi-account support
+ * Persists account metadata to ~/.opencode/openai-codex-accounts.json
+ */
+
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import type { AccountMetadata, AccountStorage } from "../types.js";
+
+/**
+ * Get the platform-specific data directory for opencode
+ */
+function getDataDir(): string {
+	const platform = process.platform;
+
+	if (platform === "win32") {
+		return join(
+			process.env.APPDATA || join(homedir(), "AppData", "Roaming"),
+			"opencode",
+		);
+	}
+
+	const xdgData =
+		process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+	return join(xdgData, "opencode");
+}
+
+/**
+ * Get the storage path for account metadata
+ */
+export function getStoragePath(): string {
+	return join(getDataDir(), "openai-codex-accounts.json");
+}
+
+/**
+ * Load accounts from storage
+ * @returns Account storage or null if not found/invalid
+ */
+export async function loadAccounts(): Promise<AccountStorage | null> {
+	try {
+		const path = getStoragePath();
+		const content = await fs.readFile(path, "utf-8");
+		const data = JSON.parse(content) as AccountStorage;
+
+		if (!Array.isArray(data.accounts)) {
+			console.warn("[openai-codex-plugin] Invalid storage format, ignoring");
+			return null;
+		}
+
+		if (data.version !== 1) {
+			console.warn(
+				"[openai-codex-plugin] Unknown storage version, ignoring",
+				data.version,
+			);
+			return null;
+		}
+
+		// Validate activeIndex
+		if (
+			typeof data.activeIndex !== "number" ||
+			!Number.isInteger(data.activeIndex)
+		) {
+			data.activeIndex = 0;
+		}
+
+		if (data.activeIndex < 0 || data.activeIndex >= data.accounts.length) {
+			data.activeIndex = 0;
+		}
+
+		return data;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return null;
+		}
+		console.error(
+			"[openai-codex-plugin] Failed to load account storage:",
+			(error as Error).message,
+		);
+		return null;
+	}
+}
+
+/**
+ * Save accounts to storage
+ * @param storage - Account storage to save
+ */
+export async function saveAccounts(storage: AccountStorage): Promise<void> {
+	try {
+		const path = getStoragePath();
+
+		await fs.mkdir(dirname(path), { recursive: true });
+
+		const content = JSON.stringify(storage, null, 2);
+		await fs.writeFile(path, content, "utf-8");
+	} catch (error) {
+		console.error(
+			"[openai-codex-plugin] Failed to save account storage:",
+			(error as Error).message,
+		);
+		throw error;
+	}
+}
+
+/**
+ * Create account storage from account data
+ */
+export function createAccountStorage(
+	accounts: Array<{
+		refreshToken: string;
+		accessToken?: string;
+		expiresAt?: number;
+		chatgptAccountId: string;
+		email?: string;
+	}>,
+): AccountStorage {
+	const now = Date.now();
+
+	return {
+		version: 1,
+		accounts: accounts.map((acc, index) => ({
+			refreshToken: acc.refreshToken,
+			chatgptAccountId: acc.chatgptAccountId,
+			email: acc.email,
+			addedAt: now,
+			lastUsed: index === 0 ? now : 0,
+		})),
+		activeIndex: 0,
+	};
+}

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,6 +1,27 @@
 import { generatePKCE } from "@openauthjs/openauth/pkce";
 import { randomBytes } from "node:crypto";
-import type { PKCEPair, AuthorizationFlow, TokenResult, ParsedAuthInput, JWTPayload } from "../types.js";
+import type {
+	PKCEPair,
+	AuthorizationFlow,
+	TokenResult,
+	ParsedAuthInput,
+	JWTPayload,
+	OAuthAuthDetails,
+	Auth,
+} from "../types.js";
+
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 60 * 1000;
+
+export function isOAuthAuth(auth: Auth): auth is OAuthAuthDetails {
+	return auth.type === "oauth";
+}
+
+export function accessTokenExpired(auth: OAuthAuthDetails): boolean {
+	if (!auth.access || typeof auth.expires !== "number") {
+		return true;
+	}
+	return auth.expires <= Date.now() + ACCESS_TOKEN_EXPIRY_BUFFER_MS;
+}
 
 // OAuth constants (from openai/codex)
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -79,3 +79,6 @@ export const AUTH_LABELS = {
 	INSTRUCTIONS_MANUAL:
 		"After logging in, copy the full redirect URL and paste it here.",
 } as const;
+
+/** Multi-account configuration */
+export const MAX_ACCOUNTS = 10;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -174,5 +174,75 @@ export interface GitHubRelease {
 	[key: string]: unknown;
 }
 
+// ============================================================================
+// Multi-Account Support Types
+// ============================================================================
+
+/**
+ * Rate limit state tracking reset times per account
+ */
+export interface RateLimitState {
+	resetTime?: number;
+}
+
+/**
+ * Stored account metadata
+ */
+export interface AccountMetadata {
+	refreshToken: string;
+	chatgptAccountId: string;
+	email?: string;
+	addedAt: number;
+	lastUsed: number;
+	lastSwitchReason?: "rate-limit" | "initial" | "rotation";
+	rateLimitResetTime?: number;
+}
+
+/**
+ * Account storage structure (persisted to disk)
+ */
+export interface AccountStorage {
+	version: 1;
+	accounts: AccountMetadata[];
+	activeIndex: number;
+}
+
+/**
+ * Managed account in memory with runtime state
+ */
+export interface ManagedAccount {
+	index: number;
+	refreshToken: string;
+	chatgptAccountId: string;
+	accessToken?: string;
+	expiresAt?: number;
+	rateLimitResetTime?: number;
+	lastUsed: number;
+	email?: string;
+	lastSwitchReason?: "rate-limit" | "initial" | "rotation";
+}
+
+/**
+ * Multi-account refresh token format
+ * Multiple accounts separated by ||
+ * Each account: refreshToken|chatgptAccountId
+ */
+export interface MultiAccountRefresh {
+	accounts: Array<{
+		refreshToken: string;
+		chatgptAccountId: string;
+	}>;
+}
+
+/**
+ * OAuth auth details with type guard
+ */
+export interface OAuthAuthDetails {
+	type: "oauth";
+	access: string;
+	refresh: string;
+	expires: number;
+}
+
 // Re-export SDK types for convenience
 export type { Auth, Provider, Model };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@openauthjs/openauth": "^0.4.3",
         "hono": "^4.10.4"
       },
+      "bin": {
+        "opencode-openai-codex-auth": "scripts/install-opencode-codex-auth.js"
+      },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.0.150",
         "@opencode-ai/sdk": "^1.0.150",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "bin": {
-    "opencode-openai-codex-auth": "./scripts/install-opencode-codex-auth.js"
+    "opencode-openai-codex-auth": "./scripts/install-opencode-codex-auth.js",
+    "codex-accounts": "./scripts/manage-accounts.js"
   },
   "files": [
     "dist/",

--- a/scripts/manage-accounts.js
+++ b/scripts/manage-accounts.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function showHelp() {
+	console.log(`
+opencode-openai-codex-auth - Multi-account management
+
+Commands:
+  add       Add a new account to existing accounts
+  list      List all configured accounts
+  remove    Remove an account by index
+  help      Show this help message
+
+Examples:
+  npx opencode-openai-codex-auth add
+  npx opencode-openai-codex-auth list
+  npx opencode-openai-codex-auth remove 1
+`);
+}
+
+async function loadModules() {
+	const { loadAccounts, saveAccounts, getStoragePath } = await import("../dist/lib/accounts/storage.js");
+	const {
+		createAuthorizationFlow,
+		exchangeAuthorizationCode,
+		decodeJWT,
+		REDIRECT_URI,
+	} = await import("../dist/lib/auth/auth.js");
+	const { startLocalOAuthServer } = await import("../dist/lib/auth/server.js");
+	const { openBrowserUrl } = await import("../dist/lib/auth/browser.js");
+	const { JWT_CLAIM_PATH } = await import("../dist/lib/constants.js");
+
+	return {
+		loadAccounts,
+		saveAccounts,
+		getStoragePath,
+		createAuthorizationFlow,
+		exchangeAuthorizationCode,
+		decodeJWT,
+		REDIRECT_URI,
+		startLocalOAuthServer,
+		openBrowserUrl,
+		JWT_CLAIM_PATH,
+	};
+}
+
+async function listAccounts() {
+	const { loadAccounts, getStoragePath } = await loadModules();
+	const storage = await loadAccounts();
+
+	if (!storage || storage.accounts.length === 0) {
+		console.log("No accounts configured.");
+		console.log(`Storage path: ${getStoragePath()}`);
+		return;
+	}
+
+	console.log(`\nConfigured accounts (${storage.accounts.length}):\n`);
+	storage.accounts.forEach((acc, index) => {
+		const active = index === storage.activeIndex ? " (active)" : "";
+		const email = acc.email ? ` - ${acc.email}` : "";
+		const rateLimited = acc.rateLimitResetTime && acc.rateLimitResetTime > Date.now()
+			? ` [rate limited until ${new Date(acc.rateLimitResetTime).toLocaleTimeString()}]`
+			: "";
+		console.log(`  ${index}: ${acc.chatgptAccountId.slice(0, 8)}...${email}${active}${rateLimited}`);
+	});
+	console.log(`\nStorage: ${getStoragePath()}`);
+}
+
+async function addAccount() {
+	const {
+		loadAccounts,
+		saveAccounts,
+		createAuthorizationFlow,
+		exchangeAuthorizationCode,
+		decodeJWT,
+		REDIRECT_URI,
+		startLocalOAuthServer,
+		openBrowserUrl,
+		JWT_CLAIM_PATH,
+	} = await loadModules();
+
+	const storage = await loadAccounts() || {
+		version: 1,
+		accounts: [],
+		activeIndex: 0,
+	};
+
+	console.log(`\nCurrently have ${storage.accounts.length} account(s). Adding new account...\n`);
+
+	const { pkce, state, url } = await createAuthorizationFlow();
+	const serverInfo = await startLocalOAuthServer({ state });
+
+	openBrowserUrl(url);
+
+	let tokens;
+	if (!serverInfo.ready) {
+		serverInfo.close();
+		console.log(`Open this URL in your browser:\n${url}\n`);
+		const rl = createInterface({ input: stdin, output: stdout });
+		try {
+			const input = await rl.question("Paste the full redirect URL here: ");
+			const urlObj = new URL(input);
+			const code = urlObj.searchParams.get("code");
+			if (!code) {
+				console.error("No authorization code found in URL");
+				process.exit(1);
+			}
+			tokens = await exchangeAuthorizationCode(code, pkce.verifier, REDIRECT_URI);
+		} finally {
+			rl.close();
+		}
+	} else {
+		console.log("Waiting for browser authentication...");
+		const result = await serverInfo.waitForCode(state);
+		serverInfo.close();
+
+		if (!result) {
+			console.error("Authentication failed or timed out");
+			process.exit(1);
+		}
+
+		tokens = await exchangeAuthorizationCode(result.code, pkce.verifier, REDIRECT_URI);
+	}
+
+	if (tokens?.type !== "success") {
+		console.error("Token exchange failed");
+		process.exit(1);
+	}
+
+	const decoded = decodeJWT(tokens.access);
+	const chatgptAccountId = decoded?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
+
+	if (!chatgptAccountId) {
+		console.error("Could not extract ChatGPT account ID from token");
+		process.exit(1);
+	}
+
+	const existing = storage.accounts.find(a => a.chatgptAccountId === chatgptAccountId);
+	if (existing) {
+		console.log(`\nAccount ${chatgptAccountId.slice(0, 8)}... already exists. Updating tokens.`);
+		existing.refreshToken = tokens.refresh;
+		existing.lastUsed = Date.now();
+	} else {
+		storage.accounts.push({
+			refreshToken: tokens.refresh,
+			chatgptAccountId,
+			addedAt: Date.now(),
+			lastUsed: 0,
+		});
+		console.log(`\nAdded account ${chatgptAccountId.slice(0, 8)}...`);
+	}
+
+	await saveAccounts(storage);
+	console.log(`Total accounts: ${storage.accounts.length}`);
+	console.log("\nNote: You may need to re-run 'opencode auth login' to update the combined refresh token.");
+}
+
+async function removeAccount() {
+	const indexArg = args[1];
+	if (indexArg === undefined) {
+		console.error("Usage: opencode-openai-codex-auth remove <index>");
+		console.error("Run 'opencode-openai-codex-auth list' to see account indices.");
+		process.exit(1);
+	}
+
+	const index = parseInt(indexArg, 10);
+	if (isNaN(index)) {
+		console.error(`Invalid index: ${indexArg}`);
+		process.exit(1);
+	}
+
+	const { loadAccounts, saveAccounts } = await loadModules();
+	const storage = await loadAccounts();
+
+	if (!storage || storage.accounts.length === 0) {
+		console.error("No accounts configured.");
+		process.exit(1);
+	}
+
+	if (index < 0 || index >= storage.accounts.length) {
+		console.error(`Index ${index} out of range. Valid: 0-${storage.accounts.length - 1}`);
+		process.exit(1);
+	}
+
+	const removed = storage.accounts.splice(index, 1)[0];
+	if (storage.activeIndex >= storage.accounts.length) {
+		storage.activeIndex = Math.max(0, storage.accounts.length - 1);
+	}
+
+	await saveAccounts(storage);
+	console.log(`Removed account ${removed.chatgptAccountId.slice(0, 8)}...`);
+	console.log(`Remaining accounts: ${storage.accounts.length}`);
+}
+
+async function main() {
+	switch (command) {
+		case "add":
+			await addAccount();
+			break;
+		case "list":
+			await listAccounts();
+			break;
+		case "remove":
+			await removeAccount();
+			break;
+		case "help":
+		case "--help":
+		case "-h":
+		case undefined:
+			await showHelp();
+			break;
+		default:
+			console.error(`Unknown command: ${command}`);
+			await showHelp();
+			process.exit(1);
+	}
+}
+
+main().catch((error) => {
+	console.error(`Error: ${error.message}`);
+	process.exit(1);
+});

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+	AccountManager,
+	parseMultiAccountRefresh,
+	formatMultiAccountRefresh,
+} from "../lib/accounts/manager.js";
+import type { OAuthAuthDetails, AccountStorage } from "../lib/types.js";
+
+describe("AccountManager", () => {
+	const createAuth = (refresh: string): OAuthAuthDetails => ({
+		type: "oauth",
+		refresh,
+		access: "access_token_123",
+		expires: Date.now() + 3600000,
+	});
+
+	describe("parseMultiAccountRefresh", () => {
+		it("parses single account", () => {
+			const result = parseMultiAccountRefresh("refresh1|account1");
+			expect(result).toHaveLength(1);
+			expect(result[0].refreshToken).toBe("refresh1");
+			expect(result[0].chatgptAccountId).toBe("account1");
+		});
+
+		it("parses multiple accounts", () => {
+			const result = parseMultiAccountRefresh(
+				"refresh1|account1||refresh2|account2||refresh3|account3",
+			);
+			expect(result).toHaveLength(3);
+			expect(result[0].refreshToken).toBe("refresh1");
+			expect(result[1].refreshToken).toBe("refresh2");
+			expect(result[2].refreshToken).toBe("refresh3");
+		});
+
+		it("handles empty string", () => {
+			const result = parseMultiAccountRefresh("");
+			expect(result).toHaveLength(0);
+		});
+
+		it("handles malformed input", () => {
+			const result = parseMultiAccountRefresh("justrefresh");
+			expect(result).toHaveLength(1);
+			expect(result[0].refreshToken).toBe("justrefresh");
+			expect(result[0].chatgptAccountId).toBe("");
+		});
+	});
+
+	describe("formatMultiAccountRefresh", () => {
+		it("formats single account", () => {
+			const accounts = [
+				{ index: 0, refreshToken: "refresh1", chatgptAccountId: "account1", lastUsed: 0 },
+			];
+			const result = formatMultiAccountRefresh(accounts);
+			expect(result).toBe("refresh1|account1");
+		});
+
+		it("formats multiple accounts", () => {
+			const accounts = [
+				{ index: 0, refreshToken: "refresh1", chatgptAccountId: "account1", lastUsed: 0 },
+				{ index: 1, refreshToken: "refresh2", chatgptAccountId: "account2", lastUsed: 0 },
+			];
+			const result = formatMultiAccountRefresh(accounts);
+			expect(result).toBe("refresh1|account1||refresh2|account2");
+		});
+	});
+
+	describe("constructor", () => {
+		it("initializes from multi-account refresh string", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.getAccountCount()).toBe(2);
+			const accounts = manager.getAccounts();
+			expect(accounts[0].refreshToken).toBe("refresh1");
+			expect(accounts[1].refreshToken).toBe("refresh2");
+		});
+
+		it("initializes from stored accounts", () => {
+			const auth = createAuth("refresh1|account1");
+			const stored: AccountStorage = {
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "stored_refresh1",
+						chatgptAccountId: "stored_account1",
+						addedAt: Date.now(),
+						lastUsed: Date.now(),
+					},
+					{
+						refreshToken: "stored_refresh2",
+						chatgptAccountId: "stored_account2",
+						addedAt: Date.now(),
+						lastUsed: 0,
+					},
+				],
+				activeIndex: 0,
+			};
+			const manager = new AccountManager(auth, stored);
+
+			expect(manager.getAccountCount()).toBe(2);
+			const accounts = manager.getAccounts();
+			expect(accounts[0].refreshToken).toBe("stored_refresh1");
+			expect(accounts[1].refreshToken).toBe("stored_refresh2");
+		});
+
+		it("initializes single account from simple refresh", () => {
+			const auth = createAuth("simple_refresh|simple_account");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.getAccountCount()).toBe(1);
+			expect(manager.getAccounts()[0].refreshToken).toBe("simple_refresh");
+		});
+	});
+
+	describe("getCurrentOrNext", () => {
+		it("returns current account if not rate limited", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			const account = manager.getCurrentOrNext();
+			expect(account).not.toBeNull();
+			expect(account!.index).toBe(0);
+		});
+
+		it("skips rate limited account", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			const first = manager.getCurrentAccount()!;
+			manager.markRateLimited(first, 60000);
+
+			const next = manager.getCurrentOrNext();
+			expect(next).not.toBeNull();
+			expect(next!.index).toBe(1);
+		});
+
+		it("returns null when all accounts are rate limited", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			const accounts = manager.getAccounts();
+			accounts.forEach((acc) => manager.markRateLimited(acc, 60000));
+
+			const next = manager.getCurrentOrNext();
+			expect(next).toBeNull();
+		});
+	});
+
+	describe("markRateLimited", () => {
+		it("sets rate limit reset time", () => {
+			const auth = createAuth("refresh1|account1");
+			const manager = new AccountManager(auth, null);
+
+			const account = manager.getCurrentAccount()!;
+			const before = Date.now();
+			manager.markRateLimited(account, 30000);
+
+			expect(account.rateLimitResetTime).toBeGreaterThanOrEqual(before + 30000);
+		});
+	});
+
+	describe("getMinWaitTime", () => {
+		it("returns 0 when account available", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.getMinWaitTime()).toBe(0);
+		});
+
+		it("returns minimum wait time when all rate limited", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			const accounts = manager.getAccounts();
+			manager.markRateLimited(accounts[0], 60000);
+			manager.markRateLimited(accounts[1], 30000);
+
+			const waitTime = manager.getMinWaitTime();
+			expect(waitTime).toBeGreaterThan(0);
+			expect(waitTime).toBeLessThanOrEqual(30000);
+		});
+	});
+
+	describe("addAccount", () => {
+		it("adds new account", () => {
+			const auth = createAuth("refresh1|account1");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.getAccountCount()).toBe(1);
+
+			manager.addAccount("refresh2", "account2", "access2", Date.now() + 3600000);
+
+			expect(manager.getAccountCount()).toBe(2);
+			const accounts = manager.getAccounts();
+			expect(accounts[1].refreshToken).toBe("refresh2");
+		});
+	});
+
+	describe("removeAccount", () => {
+		it("removes account by index", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.getAccountCount()).toBe(2);
+
+			const result = manager.removeAccount(0);
+			expect(result).toBe(true);
+			expect(manager.getAccountCount()).toBe(1);
+			expect(manager.getAccounts()[0].refreshToken).toBe("refresh2");
+		});
+
+		it("returns false for invalid index", () => {
+			const auth = createAuth("refresh1|account1");
+			const manager = new AccountManager(auth, null);
+
+			expect(manager.removeAccount(-1)).toBe(false);
+			expect(manager.removeAccount(5)).toBe(false);
+		});
+	});
+
+	describe("toAuthDetails", () => {
+		it("returns combined auth details", () => {
+			const auth = createAuth("refresh1|account1||refresh2|account2");
+			const manager = new AccountManager(auth, null);
+
+			const details = manager.toAuthDetails();
+			expect(details.type).toBe("oauth");
+			expect(details.refresh).toContain("refresh1");
+			expect(details.refresh).toContain("refresh2");
+		});
+	});
+
+	describe("accountToAuth", () => {
+		it("converts single account to auth details", () => {
+			const auth = createAuth("refresh1|account1");
+			const manager = new AccountManager(auth, null);
+
+			const account = manager.getCurrentAccount()!;
+			const details = manager.accountToAuth(account);
+
+			expect(details.type).toBe("oauth");
+			expect(details.refresh).toBe("refresh1|account1");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Multi-account authentication**: Users can authenticate up to 10 ChatGPT accounts during initial OAuth flow
- **Automatic rate limit rotation**: When a 429 response is received, automatically switches to the next available account
- **CLI management tool**: New `codex-accounts` command for add/list/remove operations outside OAuth flow

## Problem

Heavy users of the Codex plugin frequently hit ChatGPT's rate limits, causing interruptions. Users with multiple ChatGPT subscriptions (personal, work, etc.) have no way to leverage them for increased throughput.

## Solution

This PR implements multi-account management that:
1. Prompts users to add additional accounts during initial authentication
2. Persists account metadata separately for runtime state tracking
3. Automatically rotates to an available account when rate limits are hit
4. Provides a CLI tool for managing accounts after initial setup

## Changes

| File | Description |
|------|-------------|
| `lib/accounts/manager.ts` | **New** - `AccountManager` class with round-robin rotation, rate limit tracking |
| `lib/accounts/storage.ts` | **New** - Persistent storage to `~/.opencode/openai-codex-accounts.json` |
| `lib/accounts/cli.ts` | **New** - CLI prompt helper for multi-account setup |
| `scripts/manage-accounts.js` | **New** - Standalone CLI tool (`codex-accounts add/list/remove`) |
| `lib/types.ts` | Added types: `ManagedAccount`, `AccountStorage`, `OAuthAuthDetails`, `RateLimitState` |
| `lib/constants.ts` | Added `MAX_ACCOUNTS = 10` |
| `lib/auth/auth.ts` | Added `isOAuthAuth()` and `accessTokenExpired()` helpers |
| `index.ts` | Refactored OAuth flow for multi-account, automatic 429 rotation |
| `test/accounts.test.ts` | **New** - Comprehensive test coverage for account management |
| `package.json` | Added `codex-accounts` bin entry |

## How It Works

### Authentication Flow
```
opencode auth login
→ Complete first account OAuth
→ "You have 1 account(s). Add another? [y/N]: y"
→ Complete second account OAuth
→ ... repeat up to 10 accounts
```

### Refresh Token Format
Multiple accounts are encoded in the refresh token field:
```
refresh1|accountId1||refresh2|accountId2||refresh3|accountId3
```

### Rate Limit Handling
1. Request sent using current account
2. If 429 received, parse `Retry-After` header
3. Mark current account as rate-limited with reset time
4. Rotate to next available account
5. Persist state to storage file

### CLI Management
```bash
# List all configured accounts
codex-accounts list

# Add another account
codex-accounts add

# Remove account by index
codex-accounts remove 1
```

## Storage Locations

| Platform | Path |
|----------|------|
| Linux | `~/.local/share/opencode/openai-codex-accounts.json` |
| macOS | `~/.local/share/opencode/openai-codex-accounts.json` |
| Windows | `%APPDATA%/opencode/openai-codex-accounts.json` |

## Testing

Added comprehensive test suite in `test/accounts.test.ts` covering:
- Multi-account refresh token parsing/formatting
- AccountManager initialization from storage vs refresh string
- Rate limit tracking and account rotation
- Add/remove account operations
- Auth details conversion

## Backwards Compatibility

- Single-account users are unaffected (no prompt to add more unless they want to)
- Existing refresh tokens work as-is (parsed as single account)
- Storage file is only created when multiple accounts are configured