### PR TITLE
fix: support opencode.jsonc files with comment preservation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",
-        "hono": "^4.10.4"
+        "hono": "^4.10.4",
+        "jsonc-parser": "^3.3.1"
+      },
+      "bin": {
+        "opencode-openai-codex-auth": "scripts/install-opencode-codex-auth.js"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.0.150",
@@ -511,6 +515,7 @@
       "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
       "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/binary": "1.0.0"
       }
@@ -519,13 +524,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
       "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@oslojs/crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/asn1": "1.0.0",
         "@oslojs/binary": "1.0.0"
@@ -535,13 +542,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@oslojs/jwt": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
       "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/encoding": "0.4.1"
       }
@@ -550,7 +559,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
       "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -903,7 +913,6 @@
       "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -1280,7 +1289,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.4.tgz",
       "integrity": "sha512-YG/fo7zlU3KwrBL5vDpWKisLYiM+nVstBQqfr7gCPbSYURnNEP9BDxEMz8KfsDR9JX0lJWDRNc6nXX31v7ZEyg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1299,6 +1307,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -1377,7 +1391,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1613,7 +1626,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1719,7 +1731,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "dependencies": {
     "@openauthjs/openauth": "^0.4.3",
-    "hono": "^4.10.4"
+    "hono": "^4.10.4",
+    "jsonc-parser": "^3.3.1"
   },
   "overrides": {
     "hono": "^4.10.4",

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { parse, modify, applyEdits, stripComments } from 'jsonc-parser';
+
+describe('Install Script - JSONC Support', () => {
+	describe('jsonc-parser Integration', () => {
+		it('should parse JSONC with single line comments', () => {
+			const jsonc = `{
+				// This is a comment
+				"key": "value"
+			}`;
+			const result = parse(jsonc);
+			expect(result).toEqual({ key: "value" });
+		});
+
+		it('should parse JSONC with block comments', () => {
+			const jsonc = `{
+				/* This is a
+				   multi-line comment */
+				"key": "value"
+			}`;
+			const result = parse(jsonc);
+			expect(result).toEqual({ key: "value" });
+		});
+
+		it('should parse JSONC with trailing commas', () => {
+			const jsonc = `{
+				"key1": "value1",
+				"key2": "value2",
+			}`;
+			const result = parse(jsonc);
+			expect(result).toEqual({ key1: "value1", key2: "value2" });
+		});
+
+		it('should preserve comments when using modify + applyEdits', () => {
+			const original = `{
+				// Important note
+				"existingKey": "existingValue",
+				/* Another important
+				   multi-line comment */
+				"unchangedKey": "unchanged"
+			}`;
+
+			const edits = modify(original, ['existingKey'], 'newValue', {
+				formattingOptions: { tabSize: 2, insertSpaces: true, eol: '\n' }
+			});
+			const result = applyEdits(original, edits);
+
+			expect(result).toContain('// Important note');
+			expect(result).toContain('/* Another important');
+			expect(result).toContain('"unchangedKey"');
+		});
+
+		it('should preserve comments when modifying specific properties', () => {
+			const original = `{
+				// Header comment
+				"$schema": "https://opencode.ai/config.json",
+				
+				// Provider configuration
+				"provider": {
+					"openai": {
+						// Model settings
+						"models": {}
+					}
+				},
+				
+				/* Footer comment */
+				"plugin": []
+			}`;
+
+			// Modify specific nested property (not full object replacement)
+			const newModels = { "new-model": true };
+			const edits = modify(original, ['provider', 'openai', 'models'], newModels, {
+				formattingOptions: { tabSize: 2, insertSpaces: true, eol: '\n' }
+			});
+			const result = applyEdits(original, edits);
+
+			expect(result).toContain('// Header comment');
+			expect(result).toContain('// Provider configuration');
+			expect(result).toContain('// Model settings');
+			expect(result).toContain('/* Footer comment */');
+			expect(result).toContain('"new-model"');
+		});
+	});
+
+	describe('Deep Merge Logic', () => {
+		function deepMerge(target, source) {
+			const output = { ...target };
+			if (isObject(target) && isObject(source)) {
+				Object.keys(source).forEach(key => {
+					if (isObject(source[key])) {
+						if (!(key in target)) {
+							Object.assign(output, { [key]: source[key] });
+						} else {
+							output[key] = deepMerge(target[key], source[key]);
+						}
+					} else {
+						Object.assign(output, { [key]: source[key] });
+					}
+				});
+			}
+			return output;
+		}
+
+		function isObject(item) {
+			return item && typeof item === 'object' && !Array.isArray(item);
+		}
+
+		it('should merge simple objects', () => {
+			const target = { a: 1, b: 2 };
+			const source = { b: 3, c: 4 };
+			const result = deepMerge(target, source);
+			expect(result).toEqual({ a: 1, b: 3, c: 4 });
+		});
+
+		it('should deep merge nested objects', () => {
+			const target = {
+				provider: {
+					openai: {
+						models: {},
+						options: { timeout: 30000 }
+					}
+				}
+			};
+			const source = {
+				provider: {
+					openai: {
+						models: { "new-model": true },
+						apiKey: "new-key"
+					}
+				}
+			};
+			const result = deepMerge(target, source);
+			expect(result).toEqual({
+				provider: {
+					openai: {
+						models: { "new-model": true },
+						options: { timeout: 30000 },
+						apiKey: "new-key"
+					}
+				}
+			});
+		});
+
+		it('should overwrite arrays', () => {
+			const target = { plugin: ["old"] };
+			const source = { plugin: ["new"] };
+			const result = deepMerge(target, source);
+			expect(result).toEqual({ plugin: ["new"] });
+		});
+	});
+
+	describe('Edge Cases', () => {
+		it('should handle malformed JSONC gracefully', () => {
+			const malformed = `{"incomplete`;
+			expect(() => parse(malformed)).not.toThrow();
+		});
+
+		it('should handle empty JSONC file', () => {
+			const empty = '';
+			const result = parse(empty);
+			expect(result).toBeUndefined();
+		});
+
+		it('should handle JSONC with only comments', () => {
+			const onlyComments = `// Comment\n/* Block comment */`;
+			const result = parse(onlyComments);
+			expect(result).toBeUndefined();
+		});
+
+		it('should strip comments', () => {
+			const jsonc = `// Comment\n{\n  "key": "value"\n}/* End */`;
+			const cleaned = stripComments(jsonc);
+			expect(cleaned).not.toContain('// Comment');
+			expect(cleaned).not.toContain('/* End */');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #95 where install script did not detect or update existing `.jsonc` config files.

## Changes

- **Add `jsonc-parser` dependency** - Zero-dependency library from Microsoft for parsing JSON with Comments
- **Detect and prioritize `.jsonc` files** - Script now checks for `.jsonc` first, then `.json`
- **Preserve comments and formatting** - Uses `modify()` + `applyEdits()` to maintain existing structure
- **Implement deep merge logic** - Preserves user configurations while applying template updates
- **Add comprehensive tests** - 12 new tests covering JSONC parsing, comment preservation, and edge cases

## Problem

Previously, install script only checked for `~/.config/opencode/opencode.json`, completely ignoring `.jsonc` files. Since OpenCode supports both formats (per official docs), users with `.jsonc` configs would see:
```
No existing config found. Creating new global config.
Wrote /Users/renan/.config/opencode/opencode.json (modern config)
```

This resulted in duplicate config files (OpenCode merges both) and lost user customizations.

## Solution

The updated install script now:
1. **Detects config files in priority order**: `.jsonc` > `.json` > (create new `.json`)
2. **Reads with jsonc-parser**: Supports both formats, comments, trailing commas
3. **Preserves structure**: When updating `.jsonc`, maintains original comments and formatting
4. **Deep merges provider config**: Preserves user's timeout, API keys, etc. while adding template settings
5. **Clear feedback**: Logs indicate which format was detected and whether it's new or existing

## Testing

- ✅ All 235 existing tests pass
- ✅ 12 new tests in `install-script.test.ts`:
  - JSONC parsing (line comments, block comments, trailing commas)
  - Comment preservation with `modify()` + `applyEdits()`
  - Deep merge logic verification
  - Edge cases (malformed JSONC, empty files, comments-only files)
- ✅ Manual testing confirmed `.jsonc` detection and update works correctly

## Example Behavior

**Before:**
```bash
$ cat ~/.config/opencode/opencode.jsonc
{
  // My custom config
  "provider": { "openai": { "timeout": 60000 } },
  "plugin": []
}

$ npx -y opencode-openai-codex-auth@latest
No existing config found. Creating new global config.  # ❌ Wrong!
Wrote ~/.config/opencode/opencode.json
```

**After:**
```bash
$ cat ~/.config/opencode/opencode.jsonc
{
  // My custom config
  "provider": { "openai": { "timeout": 60000 } },
  "plugin": []
}

$ npx -y opencode-openai-codex-auth@latest
Backup created: ~/.config/opencode/opencode.jsonc.bak-2026-01-07_14-02-40-810
Wrote ~/.config/opencode/opencode.jsonc (modern config (existing JSONC preserved))  # ✅ Correct!
```

Closes #95