### PR TITLE
Add GPT-5.3 Codex Spark support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides coding guidance for AI agents (including Claude Code, Codex, 
 
 ## Overview
 
-This is an **opencode plugin** that enables OAuth authentication with OpenAI's ChatGPT Plus/Pro Codex backend. It allows users to access `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, and `gpt-5.1` models through their ChatGPT subscription instead of using OpenAI Platform API credits. Legacy GPT-5.0 models are automatically normalized to their GPT-5.1 equivalents.
+This is an **opencode plugin** that enables OAuth authentication with OpenAI's ChatGPT Plus/Pro Codex backend. It allows users to access `gpt-5.3-codex`, `gpt-5.3`, `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, and `gpt-5.1` models through their ChatGPT subscription instead of using OpenAI Platform API credits. Legacy GPT-5.0 models are automatically normalized to their GPT-5.1 equivalents.
 
 **Key architecture principle**: 7-step fetch flow that intercepts opencode's OpenAI SDK requests, transforms them for the ChatGPT backend API, and handles OAuth token management.
 
@@ -41,7 +41,7 @@ The main entry point orchestrates a **7-step fetch flow**:
 1. **Token Management**: Check token expiration, refresh if needed
 2. **URL Rewriting**: Transform OpenAI Platform API URLs → ChatGPT backend API (`https://chatgpt.com/backend-api/codex/responses`)
 3. **Request Transformation**:
-   - Normalize model names (all variants → `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5`, `gpt-5-codex`, or `codex-mini-latest`)
+   - Normalize model names (all variants → `gpt-5.3`, `gpt-5.3-codex`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5`, `gpt-5-codex`, or `codex-mini-latest`)
    - Inject Codex system instructions from latest GitHub release
    - Apply reasoning configuration (effort, summary, verbosity)
    - Add CODEX_MODE bridge prompt (default) or tool remap message (legacy)
@@ -98,7 +98,9 @@ The main entry point orchestrates a **7-step fetch flow**:
 - Plugin defaults: `reasoningEffort: "medium"`, `reasoningSummary: "auto"`, `textVerbosity: "medium"`
 
 **4. Model Normalization** (GPT-5.0 → GPT-5.1 migration):
-- All `gpt-5.2-codex*` variants → `gpt-5.2-codex` (newest Codex model, supports xhigh)
+- All `gpt-5.3-codex*` variants → `gpt-5.3-codex` (newest Codex model, supports xhigh)
+- All `gpt-5.3` variants → `gpt-5.3` (newest general-purpose model, supports none/low/medium/high/xhigh)
+- All `gpt-5.2-codex*` variants → `gpt-5.2-codex`
 - All `gpt-5.1-codex-max*` variants → `gpt-5.1-codex-max`
 - All `gpt-5.1-codex*` variants → `gpt-5.1-codex`
 - All `gpt-5.1-codex-mini*` variants → `gpt-5.1-codex-mini`
@@ -108,21 +110,23 @@ The main entry point orchestrates a **7-step fetch flow**:
   - `gpt-5-codex*` variants → `gpt-5.1-codex`
   - `gpt-5-codex-mini*` or `codex-mini-latest` → `gpt-5.1-codex-mini`
   - `gpt-5*` variants (including `gpt-5-mini`, `gpt-5-nano`) → `gpt-5.1`
-- `minimal` effort auto-normalized to `low` for Codex families (including GPT-5.2 Codex) and clamped to `medium` (or `high` when requested) for Codex Mini
+- `minimal` effort auto-normalized to `low` for Codex families (including GPT-5.3 Codex and GPT-5.2 Codex) and clamped to `medium` (or `high` when requested) for Codex Mini
 
 **5. Model-Specific Prompt Selection**:
 - Different prompts for different model families (matching Codex CLI):
-  - `gpt-5.2-codex*` → `gpt-5.2-codex_prompt.md` (117 lines, Codex CLI agent prompt)
-  - `gpt-5.1-codex-max*` → `gpt-5.1-codex-max_prompt.md` (117 lines, frontend design guidelines)
-  - `gpt-5.1-codex*`, `codex-*` → `gpt_5_codex_prompt.md` (105 lines, coding focus)
+  - `gpt-5.3-codex*` → `gpt-5.3-codex_prompt.md` (Codex CLI agent prompt)
+  - `gpt-5.3*` → `gpt_5_3_prompt.md` (GPT‑5.3 general family)
+  - `gpt-5.2-codex*` → `gpt-5.2-codex_prompt.md` (Codex CLI agent prompt)
+  - `gpt-5.1-codex-max*` → `gpt-5.1-codex-max_prompt.md` (frontend design guidelines)
+  - `gpt-5.1-codex*`, `codex-*` → `gpt_5_codex_prompt.md` (coding focus)
   - `gpt-5.2*` → `gpt_5_2_prompt.md` (GPT‑5.2 general family)
-  - `gpt-5.1*` → `gpt_5_1_prompt.md` (368 lines, full behavioral guidance)
+  - `gpt-5.1*` → `gpt_5_1_prompt.md` (full behavioral guidance)
 - `getModelFamily()` determines prompt selection based on normalized model
 
 **6. Codex Instructions Caching**:
 - Fetches from latest release tag (not main branch)
 - ETag-based HTTP conditional requests per model family
-- Separate cache files per family: `gpt-5.2-codex-instructions.md`, `codex-max-instructions.md`, `codex-instructions.md`, `gpt-5.2-instructions.md`, `gpt-5.1-instructions.md`
+- Separate cache files per family: `gpt-5.3-codex-instructions.md`, `gpt-5.3-instructions.md`, `gpt-5.2-codex-instructions.md`, `codex-max-instructions.md`, `codex-instructions.md`, `gpt-5.2-instructions.md`, `gpt-5.1-instructions.md`
 - Cache invalidation when release tag changes
 - Falls back to bundled version if GitHub unavailable
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ npx -y opencode-openai-codex-auth@latest --uninstall --all
 ```
 ---
 ## 📦 Models
+- **gpt-5.3-codex-spark** (low/medium/high/xhigh)
+- **gpt-5.3-codex** (low/medium/high/xhigh)
+- **gpt-5.3** (none/low/medium/high/xhigh)
 - **gpt-5.2** (none/low/medium/high/xhigh)
 - **gpt-5.2-codex** (low/medium/high/xhigh)
 - **gpt-5.1-codex-max** (low/medium/high/xhigh)
@@ -58,7 +61,7 @@ Minimal configs are not supported for GPT‑5.x; use the full configs above.
 ---
 ## ✅ Features
 - ChatGPT Plus/Pro OAuth authentication (official flow)
-- 22 model presets across GPT‑5.2 / GPT‑5.2 Codex / GPT‑5.1 families
+- Multiple GPT‑5.x model families including GPT‑5.3 / GPT‑5.3‑Codex / GPT‑5.3‑Codex‑Spark
 - Variant system support (v1.0.210+) + legacy presets
 - Multimodal input enabled for all models
 - Usage‑aware errors + automatic token refresh

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -18,6 +18,8 @@ const __dirname = dirname(__filename);
  * Maps to different system prompts in the Codex CLI
  */
 export type ModelFamily =
+	| "gpt-5.3-codex"
+	| "gpt-5.3"
 	| "gpt-5.2-codex"
 	| "codex-max"
 	| "codex"
@@ -29,6 +31,8 @@ export type ModelFamily =
  * Based on codex-rs/core/src/model_family.rs logic
  */
 const PROMPT_FILES: Record<ModelFamily, string> = {
+	"gpt-5.3-codex": "gpt-5.3-codex_prompt.md",
+	"gpt-5.3": "gpt_5_3_prompt.md",
 	"gpt-5.2-codex": "gpt-5.2-codex_prompt.md",
 	"codex-max": "gpt-5.1-codex-max_prompt.md",
 	codex: "gpt_5_codex_prompt.md",
@@ -40,6 +44,8 @@ const PROMPT_FILES: Record<ModelFamily, string> = {
  * Cache file mapping for each model family
  */
 const CACHE_FILES: Record<ModelFamily, string> = {
+	"gpt-5.3-codex": "gpt-5.3-codex-instructions.md",
+	"gpt-5.3": "gpt-5.3-instructions.md",
 	"gpt-5.2-codex": "gpt-5.2-codex-instructions.md",
 	"codex-max": "codex-max-instructions.md",
 	codex: "codex-instructions.md",
@@ -49,11 +55,20 @@ const CACHE_FILES: Record<ModelFamily, string> = {
 
 /**
  * Determine the model family based on the normalized model name
- * @param normalizedModel - The normalized model name (e.g., "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1")
+ * @param normalizedModel - The normalized model name (e.g., "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1")
  * @returns The model family for prompt selection
  */
 export function getModelFamily(normalizedModel: string): ModelFamily {
 	// Order matters - check more specific patterns first
+	if (
+		normalizedModel.includes("gpt-5.3-codex") ||
+		normalizedModel.includes("gpt 5.3 codex")
+	) {
+		return "gpt-5.3-codex";
+	}
+	if (normalizedModel.includes("gpt-5.3") || normalizedModel.includes("gpt 5.3")) {
+		return "gpt-5.3";
+	}
 	if (
 		normalizedModel.includes("gpt-5.2-codex") ||
 		normalizedModel.includes("gpt 5.2 codex")

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -18,6 +18,7 @@ const __dirname = dirname(__filename);
  * Maps to different system prompts in the Codex CLI
  */
 export type ModelFamily =
+	| "gpt-5.3-codex-spark"
 	| "gpt-5.3-codex"
 	| "gpt-5.3"
 	| "gpt-5.2-codex"
@@ -31,6 +32,7 @@ export type ModelFamily =
  * Based on codex-rs/core/src/model_family.rs logic
  */
 const PROMPT_FILES: Record<ModelFamily, string> = {
+	"gpt-5.3-codex-spark": "gpt-5.3-codex_prompt.md",
 	"gpt-5.3-codex": "gpt-5.3-codex_prompt.md",
 	"gpt-5.3": "gpt_5_3_prompt.md",
 	"gpt-5.2-codex": "gpt-5.2-codex_prompt.md",
@@ -44,6 +46,7 @@ const PROMPT_FILES: Record<ModelFamily, string> = {
  * Cache file mapping for each model family
  */
 const CACHE_FILES: Record<ModelFamily, string> = {
+	"gpt-5.3-codex-spark": "gpt-5.3-codex-instructions.md",
 	"gpt-5.3-codex": "gpt-5.3-codex-instructions.md",
 	"gpt-5.3": "gpt-5.3-instructions.md",
 	"gpt-5.2-codex": "gpt-5.2-codex-instructions.md",
@@ -60,6 +63,13 @@ const CACHE_FILES: Record<ModelFamily, string> = {
  */
 export function getModelFamily(normalizedModel: string): ModelFamily {
 	// Order matters - check more specific patterns first
+	if (
+		normalizedModel.includes("gpt-5.3-codex-spark") ||
+		normalizedModel.includes("gpt 5.3 codex spark")
+	) {
+		return "gpt-5.3-codex-spark";
+	}
+
 	if (
 		normalizedModel.includes("gpt-5.3-codex") ||
 		normalizedModel.includes("gpt 5.3 codex")

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -13,8 +13,27 @@
  */
 export const MODEL_MAP: Record<string, string> = {
 // ============================================================================
-// GPT-5.1 Codex Models
+// GPT-5.3 Models (supports none/low/medium/high/xhigh per OpenAI API docs)
 // ============================================================================
+	"gpt-5.3": "gpt-5.3",
+	"gpt-5.3-none": "gpt-5.3",
+	"gpt-5.3-low": "gpt-5.3",
+	"gpt-5.3-medium": "gpt-5.3",
+	"gpt-5.3-high": "gpt-5.3",
+	"gpt-5.3-xhigh": "gpt-5.3",
+
+	// ============================================================================
+	// GPT-5.3 Codex Models (low/medium/high/xhigh)
+	// ============================================================================
+	"gpt-5.3-codex": "gpt-5.3-codex",
+	"gpt-5.3-codex-low": "gpt-5.3-codex",
+	"gpt-5.3-codex-medium": "gpt-5.3-codex",
+	"gpt-5.3-codex-high": "gpt-5.3-codex",
+	"gpt-5.3-codex-xhigh": "gpt-5.3-codex",
+
+	// ============================================================================
+	// GPT-5.1 Codex Models
+	// ============================================================================
 	"gpt-5.1-codex": "gpt-5.1-codex",
 	"gpt-5.1-codex-low": "gpt-5.1-codex",
 	"gpt-5.1-codex-medium": "gpt-5.1-codex",

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -12,9 +12,19 @@
  * Value: The normalized model name to send to the API
  */
 export const MODEL_MAP: Record<string, string> = {
-// ============================================================================
-// GPT-5.3 Models (supports none/low/medium/high/xhigh per OpenAI API docs)
-// ============================================================================
+	// ============================================================================
+	// GPT-5.3 Codex Spark Models (text-only low-latency variant)
+	// ============================================================================
+	"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-none": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-low": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-medium": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-high": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-xhigh": "gpt-5.3-codex-spark",
+
+	// ============================================================================
+	// GPT-5.3 Models (supports none/low/medium/high/xhigh per OpenAI API docs)
+	// ============================================================================
 	"gpt-5.3": "gpt-5.3",
 	"gpt-5.3-none": "gpt-5.3",
 	"gpt-5.3-low": "gpt-5.3",

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -47,7 +47,20 @@ export function normalizeModel(model: string | undefined): string {
 	const normalized = modelId.toLowerCase();
 
 	// Priority order for pattern matching (most specific first):
-	// 1. GPT-5.2 Codex (newest codex model)
+	// 1. GPT-5.3 Codex (newest codex model)
+	if (
+		normalized.includes("gpt-5.3-codex") ||
+		normalized.includes("gpt 5.3 codex")
+	) {
+		return "gpt-5.3-codex";
+	}
+
+	// 2. GPT-5.3 (general purpose)
+	if (normalized.includes("gpt-5.3") || normalized.includes("gpt 5.3")) {
+		return "gpt-5.3";
+	}
+
+	// 3. GPT-5.2 Codex
 	if (
 		normalized.includes("gpt-5.2-codex") ||
 		normalized.includes("gpt 5.2 codex")
@@ -55,7 +68,7 @@ export function normalizeModel(model: string | undefined): string {
 		return "gpt-5.2-codex";
 	}
 
-	// 2. GPT-5.2 (general purpose)
+	// 4. GPT-5.2 (general purpose)
 	if (normalized.includes("gpt-5.2") || normalized.includes("gpt 5.2")) {
 		return "gpt-5.2";
 	}
@@ -195,7 +208,17 @@ export function getReasoningConfig(
 ): ReasoningConfig {
 	const normalizedName = modelName?.toLowerCase() ?? "";
 
-	// GPT-5.2 Codex is the newest codex model (supports xhigh, but not "none")
+	// GPT-5.3 Codex is the newest codex model (supports xhigh, but not "none")
+	const isGpt53Codex =
+		normalizedName.includes("gpt-5.3-codex") ||
+		normalizedName.includes("gpt 5.3 codex");
+
+	// GPT-5.3 general purpose (not codex variant)
+	const isGpt53General =
+		(normalizedName.includes("gpt-5.3") || normalizedName.includes("gpt 5.3")) &&
+		!isGpt53Codex;
+
+	// GPT-5.2 Codex (supports xhigh, but not "none")
 	const isGpt52Codex =
 		normalizedName.includes("gpt-5.2-codex") ||
 		normalizedName.includes("gpt 5.2 codex");
@@ -225,16 +248,16 @@ export function getReasoningConfig(
 		!isCodexMax &&
 		!isCodexMini;
 
-	// GPT 5.2, GPT 5.2 Codex, and Codex Max support xhigh reasoning
-	const supportsXhigh = isGpt52General || isGpt52Codex || isCodexMax;
+	// GPT 5.3, GPT 5.2, GPT 5.2 Codex, and Codex Max support xhigh reasoning
+	const supportsXhigh = isGpt53General || isGpt53Codex || isGpt52General || isGpt52Codex || isCodexMax;
 
-	// GPT 5.1 general and GPT 5.2 general support "none" reasoning per:
+	// GPT 5.3 general, GPT 5.2 general, and GPT 5.1 general support "none" reasoning per:
 	// - OpenAI API docs: "gpt-5.1 defaults to none, supports: none, low, medium, high"
 	// - Codex CLI: ReasoningEffort enum includes None variant (codex-rs/protocol/src/openai_models.rs)
 	// - Codex CLI: docs/config.md lists "none" as valid for model_reasoning_effort
-	// - gpt-5.2 (being newer) also supports: none, low, medium, high, xhigh
-	// - Codex models (including GPT-5.2 Codex) do NOT support "none"
-	const supportsNone = isGpt52General || isGpt51General;
+	// - gpt-5.2 and gpt-5.3 (being newer) also supports: none, low, medium, high, xhigh
+	// - Codex models (including GPT-5.2 Codex and GPT-5.3 Codex) do NOT support "none"
+	const supportsNone = isGpt53General || isGpt52General || isGpt51General;
 
 	// Default based on model type (Codex CLI defaults)
 	// Note: OpenAI docs say gpt-5.1 defaults to "none", but we default to "medium"

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -47,6 +47,14 @@ export function normalizeModel(model: string | undefined): string {
 	const normalized = modelId.toLowerCase();
 
 	// Priority order for pattern matching (most specific first):
+	// 1. GPT-5.3 Codex Spark (latest text-only coding model)
+	if (
+		normalized.includes("gpt-5.3-codex-spark") ||
+		normalized.includes("gpt 5.3 codex spark")
+	) {
+		return "gpt-5.3-codex-spark";
+	}
+
 	// 1. GPT-5.3 Codex (newest codex model)
 	if (
 		normalized.includes("gpt-5.3-codex") ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-openai-codex-auth",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-openai-codex-auth",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -110,6 +110,15 @@ describe('Request Transformer Module', () => {
 				expect(normalizeModel('openai/gpt-5.3-codex-xhigh')).toBe('gpt-5.3-codex');
 			});
 
+			it('should normalize gpt-5.3-codex-spark presets', async () => {
+				expect(normalizeModel('gpt-5.3-codex-spark')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-low')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-medium')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-high')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-xhigh')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('openai/gpt-5.3-codex-spark-xhigh')).toBe('gpt-5.3-codex-spark');
+			});
+
 			it('should normalize gpt-5.1 codex and mini slugs', async () => {
 				expect(normalizeModel('gpt-5.1-codex')).toBe('gpt-5.1-codex');
 				expect(normalizeModel('openai/gpt-5.1-codex')).toBe('gpt-5.1-codex');
@@ -132,6 +141,7 @@ describe('Request Transformer Module', () => {
 				expect(normalizeModel('GPT-5-HIGH')).toBe('gpt-5.1');
 				expect(normalizeModel('CODEx-MINI-LATEST')).toBe('gpt-5.1-codex-mini');
 				expect(normalizeModel('GPT-5.3-CODEX')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('GPT-5.3-CODEX-SPARK')).toBe('gpt-5.3-codex-spark');
 				expect(normalizeModel('GPT-5.3-HIGH')).toBe('gpt-5.3');
 			});
 
@@ -948,6 +958,16 @@ describe('Request Transformer Module', () => {
 			expect(result.reasoning?.effort).toBe('high');
 		});
 
+		it('should default gpt-5.3-codex-spark to high effort', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.3-codex-spark',
+				input: [],
+			};
+			const result = await transformRequestBody(body, codexInstructions);
+			expect(result.model).toBe('gpt-5.3-codex-spark');
+			expect(result.reasoning?.effort).toBe('high');
+		});
+
 		it('should preserve xhigh for gpt-5.3 when requested', async () => {
 			const body: RequestBody = {
 				model: 'gpt-5.3-xhigh',
@@ -982,6 +1002,25 @@ describe('Request Transformer Module', () => {
 			};
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
 			expect(result.model).toBe('gpt-5.3-codex');
+			expect(result.reasoning?.effort).toBe('xhigh');
+			expect(result.reasoning?.summary).toBe('detailed');
+		});
+
+		it('should preserve xhigh for gpt-5.3-codex-spark when requested', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.3-codex-spark-xhigh',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: { reasoningSummary: 'auto' },
+				models: {
+					'gpt-5.3-codex-spark-xhigh': {
+						options: { reasoningEffort: 'xhigh', reasoningSummary: 'detailed' },
+					},
+				},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.3-codex-spark');
 			expect(result.reasoning?.effort).toBe('xhigh');
 			expect(result.reasoning?.summary).toBe('detailed');
 		});
@@ -1105,6 +1144,20 @@ describe('Request Transformer Module', () => {
 			};
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
 			expect(result.model).toBe('gpt-5.3-codex');
+			expect(result.reasoning?.effort).toBe('low');
+		});
+
+		it('should upgrade none to low for GPT-5.3-codex-spark (codex does not support none)', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.3-codex-spark',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: { reasoningEffort: 'none' },
+				models: {},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.3-codex-spark');
 			expect(result.reasoning?.effort).toBe('low');
 		});
 


### PR DESCRIPTION
## Summary
- Add `gpt-5.3-codex-spark` model support in the same architecture pattern used for existing GPT-5.x families.
- Normalize `gpt-5.3-codex-spark-*` variants into a single API model while preserving user-facing `low/medium/high/xhigh` behavior.
- Add dedicated tests for:
  - normalization of spark variants
  - prompt/model mapping for spark families
  - reasoning effort configuration for spark path
- Update README model matrix to expose `gpt-5.3-codex-spark` with full reasoning effort coverage.

## Testing
- `npm run build`
- `npm run test`
- `npm run test -- test/request-transformer.test.ts`

## Notes
- This aligns with the project’s “one model, different reasoning effort” approach and keeps config/prompt compatibility across OpenCode modern + legacy variants where applicable.
