### PR TITLE
feat: add multi-account round-robin rotation for ChatGPT OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Minimal configs are not supported for GPT‑5.x; use the full configs above.
 - Variant system support (v1.0.210+) + legacy presets
 - Multimodal input enabled for all models
 - Usage‑aware errors + automatic token refresh
+- Multi-account pool with round-robin or sticky selection (`~/.opencode/openai-codex-accounts.json`)
 ---
 ## 📚 Docs
 - Getting Started: `docs/getting-started.md`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Uninstall:
 npx -y opencode-openai-codex-auth@latest --uninstall
 npx -y opencode-openai-codex-auth@latest --uninstall --all
 ```
+
+Installer compatibility controls:
+```bash
+# Force file:// shim mode (for OpenCode builds that skip npm plugin entry)
+OPENCODE_FORCE_COMPAT_FILE_PLUGIN=1 npx -y opencode-openai-codex-auth@latest
+
+# Disable file:// shim mode
+OPENCODE_DISABLE_COMPAT_FILE_PLUGIN=1 npx -y opencode-openai-codex-auth@latest
+```
 ---
 ## 📦 Models
 - **gpt-5.2** (none/low/medium/high/xhigh)
@@ -73,5 +82,10 @@ Minimal configs are not supported for GPT‑5.x; use the full configs above.
 ## ⚠️ Usage Notice
 This plugin is for **personal development use** with your own ChatGPT Plus/Pro subscription.
 For production or multi‑user applications, use the OpenAI Platform API.
+
+## Compatibility Note
+- Some OpenCode versions include a loader guard that skips `opencode-openai-codex-auth` when configured by package name.
+- Installer now auto-detects this and writes a neutral `file://` shim entry at `~/.opencode/plugins/codex-auth-bridge/index.mjs`.
+- If your global config contains `opencode.json.bak-*`, that is an installer rollback backup. It is safe to keep or delete after you verify config is correct.
 
 **Built for developers who value simplicity.**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -367,7 +367,9 @@ Advanced plugin settings in `~/.opencode/openai-codex-auth-config.json`:
 
 ```json
 {
-  "codexMode": true
+  "codexMode": true,
+  "accountSelectionStrategy": "round-robin",
+  "rateLimitCooldownMs": 60000
 }
 ```
 
@@ -388,6 +390,13 @@ Advanced plugin settings in `~/.opencode/openai-codex-auth-config.json`:
 CODEX_MODE=0 opencode run "task"  # Temporarily disable
 CODEX_MODE=1 opencode run "task"  # Temporarily enable
 ```
+
+### Multi-account rotation
+
+- `accountSelectionStrategy`: `"round-robin"` (default) rotates on each request, `"sticky"` keeps current account until limited.
+- `rateLimitCooldownMs`: fallback cooldown when reset headers are missing.
+- Account pool is stored in `~/.opencode/openai-codex-accounts.json` and is auto-merged when you log in again.
+- To add more accounts, run `opencode auth login` again with another ChatGPT account.
 
 ### Prompt caching
 
@@ -417,6 +426,7 @@ CODEX_MODE=1 opencode run "task"  # Temporarily enable
 - `~/.config/opencode/opencode.json` - Global config (fallback)
 - `<project>/.opencode.json` - Project-specific config
 - `~/.opencode/openai-codex-auth-config.json` - Plugin config
+- `~/.opencode/openai-codex-accounts.json` - Multi-account pool state
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,6 +67,32 @@ lsof -i :1455
 - Stop Codex CLI if running
 - Both use port 1455 for OAuth
 
+### Plugin Configured But Not Loaded
+
+**Symptoms:**
+- Plugin is listed in `~/.config/opencode/opencode.json` but logs do not show it loading
+- Account pool file never appears at `~/.opencode/openai-codex-accounts.json`
+
+**Cause:**
+- Some OpenCode versions skip `opencode-openai-codex-auth` by package-name match in the plugin loader
+
+**Fix:**
+```bash
+# Re-run installer (auto-detects and enables file:// shim mode when needed)
+npx -y opencode-openai-codex-auth@latest
+
+# Force shim mode manually if needed
+OPENCODE_FORCE_COMPAT_FILE_PLUGIN=1 npx -y opencode-openai-codex-auth@latest
+```
+
+**Verify:**
+```bash
+opencode run "ping" --model=openai/gpt-5.2 --variant=medium --print-logs --log-level DEBUG
+node scripts/debug-account-pool.js
+```
+
+You should see plugin loading from a `file://.../codex-auth-bridge/index.mjs` entry and a populated account pool file.
+
 ### "Invalid Session" or "Authorization session expired"
 
 **Symptoms:**

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ import {
 	decodeJWT,
 	exchangeAuthorizationCode,
 	parseAuthorizationInput,
+	refreshAccessToken,
 	REDIRECT_URI,
 } from "./lib/auth/auth.js";
 import { openBrowserUrl } from "./lib/auth/browser.js";
@@ -41,8 +42,6 @@ import {
 	ERROR_MESSAGES,
 	JWT_CLAIM_PATH,
 	LOG_STAGES,
-	OPENAI_HEADER_VALUES,
-	OPENAI_HEADERS,
 	PLUGIN_NAME,
 	PROVIDER_ID,
 } from "./lib/constants.js";
@@ -52,12 +51,11 @@ import {
 	extractRequestUrl,
 	handleErrorResponse,
 	handleSuccessResponse,
-	refreshAndUpdateToken,
 	rewriteUrlForCodex,
-	shouldRefreshToken,
 	transformRequestForCodex,
 } from "./lib/request/fetch-helpers.js";
-import type { UserConfig } from "./lib/types.js";
+import type { RequestBody, UserConfig } from "./lib/types.js";
+import { AccountPool } from "./lib/account-pool.js";
 
 /**
  * OpenAI Codex OAuth authentication plugin for opencode
@@ -140,6 +138,22 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				// Priority: CODEX_MODE env var > config file > default (true)
 				const pluginConfig = loadPluginConfig();
 				const codexMode = getCodexMode(pluginConfig);
+				const accountSelectionStrategy =
+					pluginConfig.accountSelectionStrategy === "sticky" ? "sticky" : "round-robin";
+				const rateLimitCooldownMs = pluginConfig.rateLimitCooldownMs;
+
+				const accountPool = AccountPool.load();
+				accountPool.upsert({
+					accountId,
+					access: auth.access,
+					refresh: auth.refresh,
+					expires: auth.expires,
+					email:
+						typeof decoded?.email === "string"
+							? decoded.email
+							: undefined,
+				});
+				accountPool.save();
 
 				// Return SDK configuration
 				return {
@@ -164,10 +178,22 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						input: Request | string | URL,
 						init?: RequestInit,
 					): Promise<Response> {
-						// Step 1: Check and refresh token if needed
-						let currentAuth = await getAuth();
-						if (shouldRefreshToken(currentAuth)) {
-							currentAuth = await refreshAndUpdateToken(currentAuth, client);
+						const latestAuth = await getAuth();
+						if (latestAuth.type === "oauth") {
+							const latestDecoded = decodeJWT(latestAuth.access);
+							const latestAccountId = latestDecoded?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
+							if (latestAccountId) {
+								accountPool.upsert({
+									accountId: latestAccountId,
+									access: latestAuth.access,
+									refresh: latestAuth.refresh,
+									expires: latestAuth.expires,
+									email:
+										typeof latestDecoded?.email === "string"
+											? latestDecoded.email
+											: undefined,
+								});
+							}
 						}
 
 						// Step 2: Extract and rewrite URL for Codex backend
@@ -189,39 +215,95 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						);
 						const requestInit = transformation?.updatedInit ?? init;
 
-						// Step 4: Create headers with OAuth and ChatGPT account info
-						const accessToken =
-							currentAuth.type === "oauth" ? currentAuth.access : "";
-						const headers = createCodexHeaders(
-							requestInit,
-							accountId,
-							accessToken,
-							{
-								model: transformation?.body.model,
-								promptCacheKey: (transformation?.body as any)?.prompt_cache_key,
-							},
-						);
+						const attempts = Math.max(accountPool.count(), 1);
+						let lastRateLimitResponse: Response | null = null;
+						for (let i = 0; i < attempts; i++) {
+							const selected = accountPool.next(accountSelectionStrategy);
+							if (!selected) {
+								break;
+							}
 
-						// Step 5: Make request to Codex API
-						const response = await fetch(url, {
-							...requestInit,
-							headers,
-						});
+							if (selected.expires < Date.now()) {
+								const refreshed = await refreshAccessToken(selected.refresh);
+								if (refreshed.type === "failed") {
+									accountPool.markRateLimited(
+										selected.accountId,
+										new Headers(),
+										rateLimitCooldownMs,
+									);
+									accountPool.save();
+									continue;
+								}
+								accountPool.replaceAuth(
+									selected.accountId,
+									refreshed.access,
+									refreshed.refresh,
+									refreshed.expires,
+								);
+								if (latestAuth.type === "oauth" && latestAuth.refresh === selected.refresh) {
+									await client.auth.set({
+										path: { id: "openai" },
+										body: {
+											type: "oauth",
+											access: refreshed.access,
+											refresh: refreshed.refresh,
+											expires: refreshed.expires,
+										},
+									});
+								}
+							}
 
-						// Step 6: Log response
-						logRequest(LOG_STAGES.RESPONSE, {
-							status: response.status,
-							ok: response.ok,
-							statusText: response.statusText,
-							headers: Object.fromEntries(response.headers.entries()),
-						});
+							const headers = createCodexHeaders(
+								requestInit,
+								selected.accountId,
+								selected.access,
+								{
+									model: transformation?.body.model,
+									promptCacheKey: (transformation?.body as RequestBody | undefined)
+										?.prompt_cache_key,
+								},
+							);
 
-						// Step 7: Handle error or success response
-						if (!response.ok) {
-							return await handleErrorResponse(response);
+							const response = await fetch(url, {
+								...requestInit,
+								headers,
+							});
+
+							logRequest(LOG_STAGES.RESPONSE, {
+								status: response.status,
+								ok: response.ok,
+								statusText: response.statusText,
+								headers: Object.fromEntries(response.headers.entries()),
+								accountId: selected.accountId,
+								attempt: i + 1,
+								totalAttempts: attempts,
+							});
+
+							if (!response.ok) {
+								const mapped = await handleErrorResponse(response);
+								if (mapped.status === 429) {
+									accountPool.markRateLimited(
+										selected.accountId,
+										mapped.headers,
+										rateLimitCooldownMs,
+									);
+									accountPool.save();
+									lastRateLimitResponse = mapped;
+									continue;
+								}
+								accountPool.save();
+								return mapped;
+							}
+
+							accountPool.save();
+							return await handleSuccessResponse(response, isStreaming);
 						}
 
-						return await handleSuccessResponse(response, isStreaming);
+						accountPool.save();
+						if (lastRateLimitResponse) {
+							return lastRateLimitResponse;
+						}
+						throw new Error("No available ChatGPT account in account pool");
 					},
 				};
 			},

--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,7 @@ import {
 	PLUGIN_NAME,
 	PROVIDER_ID,
 } from "./lib/constants.js";
-import { logRequest, logDebug } from "./lib/logger.js";
+import { logRequest, logDebug, logWarn } from "./lib/logger.js";
 import {
 	createCodexHeaders,
 	extractRequestUrl,
@@ -143,6 +143,13 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				const rateLimitCooldownMs = pluginConfig.rateLimitCooldownMs;
 
 				const accountPool = AccountPool.load();
+				const savePool = () => {
+					try {
+						accountPool.save();
+					} catch (error) {
+						logWarn("Failed to persist account pool", error);
+					}
+				};
 				accountPool.upsert({
 					accountId,
 					access: auth.access,
@@ -153,7 +160,7 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							? decoded.email
 							: undefined,
 				});
-				accountPool.save();
+				savePool();
 
 				// Return SDK configuration
 				return {
@@ -179,9 +186,11 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						init?: RequestInit,
 					): Promise<Response> {
 						const latestAuth = await getAuth();
+						let latestAccountIdFromAuth: string | undefined;
 						if (latestAuth.type === "oauth") {
 							const latestDecoded = decodeJWT(latestAuth.access);
 							const latestAccountId = latestDecoded?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
+							latestAccountIdFromAuth = latestAccountId;
 							if (latestAccountId) {
 								accountPool.upsert({
 									accountId: latestAccountId,
@@ -204,7 +213,14 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						// Instructions are fetched per model family (codex-max, codex, gpt-5.1)
 						// Capture original stream value before transformation
 						// generateText() sends no stream field, streamText() sends stream=true
-						const originalBody = init?.body ? JSON.parse(init.body as string) : {};
+						let originalBody: Partial<RequestBody> = {};
+						if (typeof init?.body === "string") {
+							try {
+								originalBody = JSON.parse(init.body) as Partial<RequestBody>;
+							} catch {
+								originalBody = {};
+							}
+						}
 						const isStreaming = originalBody.stream === true;
 
 						const transformation = await transformRequestForCodex(
@@ -224,6 +240,7 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							}
 
 							if (selected.expires < Date.now()) {
+								const selectedRefreshBefore = selected.refresh;
 								const refreshed = await refreshAccessToken(selected.refresh);
 								if (refreshed.type === "failed") {
 									accountPool.markRateLimited(
@@ -231,7 +248,7 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										new Headers(),
 										rateLimitCooldownMs,
 									);
-									accountPool.save();
+									savePool();
 									continue;
 								}
 								accountPool.replaceAuth(
@@ -240,7 +257,11 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									refreshed.refresh,
 									refreshed.expires,
 								);
-								if (latestAuth.type === "oauth" && latestAuth.refresh === selected.refresh) {
+								if (
+									latestAuth.type === "oauth" &&
+									(latestAuth.refresh === selectedRefreshBefore ||
+										latestAccountIdFromAuth === selected.accountId)
+								) {
 									await client.auth.set({
 										path: { id: "openai" },
 										body: {
@@ -287,23 +308,41 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										mapped.headers,
 										rateLimitCooldownMs,
 									);
-									accountPool.save();
+									savePool();
 									lastRateLimitResponse = mapped;
 									continue;
 								}
-								accountPool.save();
+								savePool();
 								return mapped;
 							}
 
-							accountPool.save();
+							savePool();
 							return await handleSuccessResponse(response, isStreaming);
 						}
 
-						accountPool.save();
+						savePool();
 						if (lastRateLimitResponse) {
 							return lastRateLimitResponse;
 						}
-						throw new Error("No available ChatGPT account in account pool");
+						const retryAfterMs = accountPool.getMinRetryAfterMs();
+						const retryAfterSeconds = retryAfterMs ? Math.max(1, Math.ceil(retryAfterMs / 1000)) : null;
+						return new Response(
+							JSON.stringify({
+								error: {
+									code: "usage_limit_reached",
+									message: "All ChatGPT accounts are temporarily rate-limited",
+								},
+							}),
+							{
+								status: 429,
+								headers: {
+									"content-type": "application/json",
+									...(retryAfterSeconds
+										? { "retry-after": String(retryAfterSeconds) }
+										: {}),
+								},
+							},
+						);
 					},
 				};
 			},

--- a/index.ts
+++ b/index.ts
@@ -262,15 +262,19 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									(latestAuth.refresh === selectedRefreshBefore ||
 										latestAccountIdFromAuth === selected.accountId)
 								) {
-									await client.auth.set({
-										path: { id: "openai" },
-										body: {
-											type: "oauth",
-											access: refreshed.access,
-											refresh: refreshed.refresh,
-											expires: refreshed.expires,
-										},
-									});
+									try {
+										await client.auth.set({
+											path: { id: "openai" },
+											body: {
+												type: "oauth",
+												access: refreshed.access,
+												refresh: refreshed.refresh,
+												expires: refreshed.expires,
+											},
+										});
+									} catch (error) {
+										logWarn("Failed to persist refreshed auth", error);
+									}
 								}
 							}
 

--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,73 @@ import { AccountPool } from "./lib/account-pool.js";
  * ```
  */
 export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
+	const TRANSIENT_RETRY_STATUSES = new Set([500, 502, 503, 504, 529]);
+	const MAX_TRANSIENT_RETRIES = 2;
+	const BASE_TRANSIENT_BACKOFF_MS = 300;
+	const MAX_TRANSIENT_BACKOFF_MS = 5000;
+
+	const sleep = async (ms: number): Promise<void> => {
+		await new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
+	};
+
+	const parseRetryAfterMs = (headers: Headers): number | null => {
+		const retryAfter = headers.get("retry-after");
+		if (!retryAfter) return null;
+
+		const delaySeconds = Number.parseInt(retryAfter, 10);
+		if (!Number.isNaN(delaySeconds) && delaySeconds > 0) {
+			return delaySeconds * 1000;
+		}
+
+		const retryDateMs = Date.parse(retryAfter);
+		if (Number.isNaN(retryDateMs)) return null;
+		const remainingMs = retryDateMs - Date.now();
+		if (remainingMs <= 0) return null;
+		return remainingMs;
+	};
+
+	const getTransientRetryDelayMs = (retry: number, headers: Headers): number => {
+		const retryAfterMs = parseRetryAfterMs(headers);
+		if (retryAfterMs && retryAfterMs > 0) {
+			return Math.min(retryAfterMs, MAX_TRANSIENT_BACKOFF_MS);
+		}
+
+		const exponentialDelay = Math.min(
+			BASE_TRANSIENT_BACKOFF_MS * 2 ** retry,
+			MAX_TRANSIENT_BACKOFF_MS,
+		);
+		const jitterFloor = Math.floor(exponentialDelay / 2);
+		const jitterRange = exponentialDelay - jitterFloor;
+		return jitterFloor + Math.floor(Math.random() * Math.max(1, jitterRange));
+	};
+
+	const persistOAuthAccountInPool = (tokens: {
+		access: string;
+		refresh: string;
+		expires: number;
+	}) => {
+		const decoded = decodeJWT(tokens.access);
+		const tokenAccountId = decoded?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
+		if (!tokenAccountId) {
+			return;
+		}
+		try {
+			const pool = AccountPool.load();
+			pool.upsert({
+				accountId: tokenAccountId,
+				access: tokens.access,
+				refresh: tokens.refresh,
+				expires: tokens.expires,
+				email: typeof decoded?.email === "string" ? decoded.email : undefined,
+			});
+			pool.save();
+		} catch (error) {
+			logWarn("Failed to persist account in pool after OAuth", error);
+		}
+	};
+
 	const buildManualOAuthFlow = (pkce: { verifier: string }, url: string) => ({
 		url,
 		method: "code" as const,
@@ -87,7 +154,11 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				pkce.verifier,
 				REDIRECT_URI,
 			);
-			return tokens?.type === "success" ? tokens : { type: "failed" as const };
+			if (tokens?.type === "success") {
+				persistOAuthAccountInPool(tokens);
+				return tokens;
+			}
+			return { type: "failed" as const };
 		},
 	});
 	return {
@@ -289,10 +360,36 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								},
 							);
 
-							const response = await fetch(url, {
-								...requestInit,
-								headers,
-							});
+							let response: Response | null = null;
+							let transientRetries = 0;
+							for (; transientRetries <= MAX_TRANSIENT_RETRIES; transientRetries++) {
+								response = await fetch(url, {
+									...requestInit,
+									headers,
+								});
+
+								if (!TRANSIENT_RETRY_STATUSES.has(response.status)) {
+									break;
+								}
+								if (transientRetries >= MAX_TRANSIENT_RETRIES) {
+									break;
+								}
+
+								const delayMs = getTransientRetryDelayMs(
+									transientRetries,
+									response.headers,
+								);
+								logWarn("Transient upstream error, retrying request", {
+									status: response.status,
+									accountId: selected.accountId,
+									retry: transientRetries + 1,
+									delayMs,
+								});
+								await sleep(delayMs);
+							}
+							if (!response) {
+								continue;
+							}
 
 							logRequest(LOG_STAGES.RESPONSE, {
 								status: response.status,
@@ -302,6 +399,7 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								accountId: selected.accountId,
 								attempt: i + 1,
 								totalAttempts: attempts,
+								transientRetries,
 							});
 
 							if (!response.ok) {
@@ -350,10 +448,10 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					},
 				};
 			},
-				methods: [
-					{
-						label: AUTH_LABELS.OAUTH,
-						type: "oauth" as const,
+			methods: [
+				{
+					label: AUTH_LABELS.OAUTH,
+					type: "oauth" as const,
 					/**
 					 * OAuth authorization flow
 					 *
@@ -396,25 +494,27 @@ export const OpenAIAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									REDIRECT_URI,
 								);
 
-								return tokens?.type === "success"
-									? tokens
-									: { type: "failed" as const };
+								if (tokens?.type === "success") {
+									persistOAuthAccountInPool(tokens);
+									return tokens;
+								}
+								return { type: "failed" as const };
 							},
 						};
 					},
+				},
+				{
+					label: AUTH_LABELS.OAUTH_MANUAL,
+					type: "oauth" as const,
+					authorize: async () => {
+						const { pkce, url } = await createAuthorizationFlow();
+						return buildManualOAuthFlow(pkce, url);
 					},
-					{
-						label: AUTH_LABELS.OAUTH_MANUAL,
-						type: "oauth" as const,
-						authorize: async () => {
-							const { pkce, url } = await createAuthorizationFlow();
-							return buildManualOAuthFlow(pkce, url);
-						},
-					},
-					{
-						label: AUTH_LABELS.API_KEY,
-						type: "api" as const,
-					},
+				},
+				{
+					label: AUTH_LABELS.API_KEY,
+					type: "api" as const,
+				},
 			],
 		},
 	};

--- a/lib/account-pool.ts
+++ b/lib/account-pool.ts
@@ -1,0 +1,207 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { AccountPoolEntry, AccountPoolStorage } from "./types.js";
+
+const STORAGE_VERSION = 1;
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+function storagePath(): string {
+	if (process.env.OPENAI_CODEX_ACCOUNTS_PATH) {
+		return process.env.OPENAI_CODEX_ACCOUNTS_PATH;
+	}
+	return join(homedir(), ".opencode", "openai-codex-accounts.json");
+}
+
+function clampIndex(index: number, size: number): number {
+	if (!Number.isFinite(index) || size <= 0) return 0;
+	const n = Math.floor(index);
+	if (n < 0) return 0;
+	if (n >= size) return size - 1;
+	return n;
+}
+
+function now(): number {
+	return Date.now();
+}
+
+function normalizeEntry(entry: AccountPoolEntry): AccountPoolEntry | null {
+	if (!entry.accountId || !entry.refresh || !entry.access || !Number.isFinite(entry.expires)) {
+		return null;
+	}
+	return {
+		accountId: entry.accountId,
+		refresh: entry.refresh,
+		access: entry.access,
+		expires: Math.floor(entry.expires),
+		email: entry.email,
+		lastUsed: entry.lastUsed,
+		rateLimitedUntil: entry.rateLimitedUntil,
+	};
+}
+
+function parseStorage(raw: string): AccountPoolStorage | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object") return null;
+	const obj = parsed as Partial<AccountPoolStorage>;
+	const accounts = Array.isArray(obj.accounts)
+		? obj.accounts
+				.map((e) => normalizeEntry(e as AccountPoolEntry))
+				.filter((e): e is AccountPoolEntry => e !== null)
+		: [];
+	return {
+		version: STORAGE_VERSION,
+		activeIndex: clampIndex(Number(obj.activeIndex ?? 0), accounts.length || 1),
+		accounts,
+	};
+}
+
+function normalizeCooldown(cooldownMs?: number): number {
+	if (!Number.isFinite(cooldownMs) || (cooldownMs as number) < 1000) {
+		return DEFAULT_COOLDOWN_MS;
+	}
+	return Math.floor(cooldownMs as number);
+}
+
+function retryAfterFromHeaders(headers: Headers, fallbackMs: number): number {
+	const retryAfterMs = headers.get("retry-after-ms");
+	if (retryAfterMs) {
+		const parsed = Number.parseInt(retryAfterMs, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+	}
+	const retryAfter = headers.get("retry-after");
+	if (retryAfter) {
+		const parsed = Number.parseInt(retryAfter, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) return parsed * 1000;
+	}
+	const codexPrimary = headers.get("x-codex-primary-reset-after-seconds");
+	if (codexPrimary) {
+		const parsed = Number.parseInt(codexPrimary, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) return parsed * 1000;
+	}
+	return fallbackMs;
+}
+
+export class AccountPool {
+	private accounts: AccountPoolEntry[] = [];
+	private activeIndex = 0;
+
+	static load(): AccountPool {
+		const pool = new AccountPool();
+		const path = storagePath();
+		if (!existsSync(path)) return pool;
+		try {
+			const raw = readFileSync(path, "utf8");
+			const parsed = parseStorage(raw);
+			if (!parsed) return pool;
+			pool.accounts = parsed.accounts;
+			pool.activeIndex = clampIndex(parsed.activeIndex, parsed.accounts.length || 1);
+			return pool;
+		} catch {
+			return pool;
+		}
+	}
+
+	save(): void {
+		const path = storagePath();
+		const dir = dirname(path);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		const payload: AccountPoolStorage = {
+			version: STORAGE_VERSION,
+			activeIndex: clampIndex(this.activeIndex, this.accounts.length || 1),
+			accounts: this.accounts,
+		};
+		writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+	}
+
+	upsert(entry: AccountPoolEntry): void {
+		const normalized = normalizeEntry(entry);
+		if (!normalized) return;
+		const byAccount = this.accounts.findIndex((a) => a.accountId === normalized.accountId);
+		const byEmail =
+			normalized.email && byAccount < 0
+				? this.accounts.findIndex((a) => a.email && a.email === normalized.email)
+				: -1;
+		const idx = byAccount >= 0 ? byAccount : byEmail;
+		if (idx >= 0) {
+			const existing = this.accounts[idx];
+			if (!existing) return;
+			this.accounts[idx] = {
+				...existing,
+				...normalized,
+				rateLimitedUntil: existing.rateLimitedUntil,
+			};
+		} else {
+			this.accounts.push(normalized);
+		}
+		this.activeIndex = clampIndex(this.activeIndex, this.accounts.length || 1);
+	}
+
+	count(): number {
+		return this.accounts.length;
+	}
+
+	getAvailableCount(): number {
+		const t = now();
+		return this.accounts.filter((a) => !a.rateLimitedUntil || a.rateLimitedUntil <= t).length;
+	}
+
+	markRateLimited(accountId: string, headers: Headers, cooldownMs?: number): void {
+		const account = this.accounts.find((a) => a.accountId === accountId);
+		if (!account) return;
+		const fallback = normalizeCooldown(cooldownMs);
+		const retryAfter = retryAfterFromHeaders(headers, fallback);
+		account.rateLimitedUntil = now() + retryAfter;
+	}
+
+	next(strategy: "sticky" | "round-robin"): AccountPoolEntry | null {
+		if (this.accounts.length === 0) return null;
+		this.clearExpiredLimits();
+		if (strategy === "sticky") {
+			const current = this.accounts[this.activeIndex];
+			if (current && !this.isLimited(current)) {
+				current.lastUsed = now();
+				return current;
+			}
+		}
+
+		const start = strategy === "round-robin" ? (this.activeIndex + 1) % this.accounts.length : this.activeIndex;
+		for (let i = 0; i < this.accounts.length; i++) {
+			const idx = (start + i) % this.accounts.length;
+			const candidate = this.accounts[idx];
+			if (!candidate || this.isLimited(candidate)) continue;
+			this.activeIndex = idx;
+			candidate.lastUsed = now();
+			return candidate;
+		}
+		return null;
+	}
+
+	replaceAuth(accountId: string, access: string, refresh: string, expires: number): void {
+		const account = this.accounts.find((a) => a.accountId === accountId);
+		if (!account) return;
+		account.access = access;
+		account.refresh = refresh;
+		account.expires = expires;
+	}
+
+	private isLimited(account: AccountPoolEntry): boolean {
+		return !!account.rateLimitedUntil && account.rateLimitedUntil > now();
+	}
+
+	private clearExpiredLimits(): void {
+		const t = now();
+		for (const account of this.accounts) {
+			if (account.rateLimitedUntil && account.rateLimitedUntil <= t) {
+				delete account.rateLimitedUntil;
+			}
+		}
+	}
+}

--- a/lib/account-pool.ts
+++ b/lib/account-pool.ts
@@ -1,5 +1,6 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import type { AccountPoolEntry, AccountPoolStorage } from "./types.js";
 
@@ -69,15 +70,23 @@ function normalizeCooldown(cooldownMs?: number): number {
 }
 
 function retryAfterFromHeaders(headers: Headers, fallbackMs: number): number {
+	const maxRetryMs = 86_400_000;
 	const retryAfterMs = headers.get("retry-after-ms");
 	if (retryAfterMs) {
 		const parsed = Number.parseInt(retryAfterMs, 10);
-		if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+		if (!Number.isNaN(parsed) && parsed > 0 && parsed <= maxRetryMs) return parsed;
 	}
 	const retryAfter = headers.get("retry-after");
 	if (retryAfter) {
-		const parsed = Number.parseInt(retryAfter, 10);
-		if (!Number.isNaN(parsed) && parsed > 0) return parsed * 1000;
+		const seconds = Number.parseInt(retryAfter, 10);
+		if (!Number.isNaN(seconds) && seconds > 0 && seconds * 1000 <= maxRetryMs) {
+			return seconds * 1000;
+		}
+		const retryDateMs = Date.parse(retryAfter);
+		if (!Number.isNaN(retryDateMs)) {
+			const remaining = retryDateMs - now();
+			if (remaining > 0 && remaining <= maxRetryMs) return remaining;
+		}
 	}
 	const codexPrimary = headers.get("x-codex-primary-reset-after-seconds");
 	if (codexPrimary) {
@@ -118,7 +127,7 @@ export class AccountPool {
 			activeIndex: clampIndex(this.activeIndex, this.accounts.length || 1),
 			accounts: this.accounts,
 		};
-		const tempPath = `${path}.tmp.${process.pid}.${Date.now()}`;
+		const tempPath = `${path}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
 		writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
 			encoding: "utf8",
 			mode: 0o600,

--- a/lib/account-pool.ts
+++ b/lib/account-pool.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AccountPoolEntry, AccountPoolStorage } from "./types.js";
@@ -118,7 +118,16 @@ export class AccountPool {
 			activeIndex: clampIndex(this.activeIndex, this.accounts.length || 1),
 			accounts: this.accounts,
 		};
-		writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+		const tempPath = `${path}.tmp.${process.pid}.${Date.now()}`;
+		writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
+			encoding: "utf8",
+			mode: 0o600,
+		});
+		renameSync(tempPath, path);
+		try {
+			chmodSync(path, 0o600);
+		} catch {
+		}
 	}
 
 	upsert(entry: AccountPoolEntry): void {
@@ -133,9 +142,16 @@ export class AccountPool {
 		if (idx >= 0) {
 			const existing = this.accounts[idx];
 			if (!existing) return;
+			const incomingIsOlder = normalized.expires < existing.expires;
+			const nextAccess = incomingIsOlder ? existing.access : normalized.access;
+			const nextRefresh = incomingIsOlder ? existing.refresh : normalized.refresh;
+			const nextExpires = incomingIsOlder ? existing.expires : normalized.expires;
 			this.accounts[idx] = {
 				...existing,
 				...normalized,
+				access: nextAccess,
+				refresh: nextRefresh,
+				expires: nextExpires,
 				rateLimitedUntil: existing.rateLimitedUntil,
 			};
 		} else {
@@ -151,6 +167,19 @@ export class AccountPool {
 	getAvailableCount(): number {
 		const t = now();
 		return this.accounts.filter((a) => !a.rateLimitedUntil || a.rateLimitedUntil <= t).length;
+	}
+
+	getMinRetryAfterMs(): number | null {
+		const t = now();
+		let min: number | null = null;
+		for (const account of this.accounts) {
+			if (!account.rateLimitedUntil || account.rateLimitedUntil <= t) continue;
+			const remaining = account.rateLimitedUntil - t;
+			if (min === null || remaining < min) {
+				min = remaining;
+			}
+		}
+		return min;
 	}
 
 	markRateLimited(accountId: string, headers: Headers, cooldownMs?: number): void {

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -148,7 +148,6 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenRes
 		};
 		if (
 			!json?.access_token ||
-			!json?.refresh_token ||
 			typeof json?.expires_in !== "number"
 		) {
 			console.error(
@@ -161,7 +160,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenRes
 		return {
 			type: "success",
 			access: json.access_token,
-			refresh: json.refresh_token,
+			refresh: json.refresh_token || refreshToken,
 			expires: Date.now() + json.expires_in * 1000,
 		};
 	} catch (error) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,6 +11,8 @@ const CONFIG_PATH = join(homedir(), ".opencode", "openai-codex-auth-config.json"
  */
 const DEFAULT_CONFIG: PluginConfig = {
 	codexMode: true,
+	accountSelectionStrategy: "round-robin",
+	rateLimitCooldownMs: 60_000,
 };
 
 /**

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,7 +18,9 @@ export const PROVIDER_ID = "openai";
 /** HTTP Status Codes */
 export const HTTP_STATUS = {
 	OK: 200,
+	BAD_REQUEST: 400,
 	UNAUTHORIZED: 401,
+	FORBIDDEN: 403,
 	NOT_FOUND: 404,
 	TOO_MANY_REQUESTS: 429,
 } as const;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -203,7 +203,7 @@ export function createCodexHeaders(
 export async function handleErrorResponse(
     response: Response,
 ): Promise<Response> {
-	const mapped = await mapUsageLimit404(response);
+	const mapped = await mapUsageLimitTo429(response);
 	const finalResponse = mapped ?? response;
 
 	logRequest(LOG_STAGES.ERROR_RESPONSE, {
@@ -241,8 +241,14 @@ export async function handleSuccessResponse(
 	});
 }
 
-async function mapUsageLimit404(response: Response): Promise<Response | null> {
-	if (response.status !== HTTP_STATUS.NOT_FOUND) return null;
+async function mapUsageLimitTo429(response: Response): Promise<Response | null> {
+	const retryableUsageStatuses = new Set<number>([
+		HTTP_STATUS.BAD_REQUEST,
+		HTTP_STATUS.UNAUTHORIZED,
+		HTTP_STATUS.FORBIDDEN,
+		HTTP_STATUS.NOT_FOUND,
+	]);
+	if (!retryableUsageStatuses.has(response.status)) return null;
 
 	const clone = response.clone();
 	let text = "";

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,6 +9,24 @@ export interface PluginConfig {
 	 * @default true
 	 */
 	codexMode?: boolean;
+	accountSelectionStrategy?: "sticky" | "round-robin";
+	rateLimitCooldownMs?: number;
+}
+
+export interface AccountPoolEntry {
+	accountId: string;
+	refresh: string;
+	access: string;
+	expires: number;
+	email?: string;
+	lastUsed?: number;
+	rateLimitedUntil?: number;
+}
+
+export interface AccountPoolStorage {
+	version: 1;
+	activeIndex: number;
+	accounts: AccountPoolEntry[];
 }
 
 /**

--- a/scripts/install-opencode-codex-auth.js
+++ b/scripts/install-opencode-codex-auth.js
@@ -56,6 +56,7 @@ const pluginConfigPath = join(
 	".opencode",
 	"openai-codex-auth-config.json",
 );
+const pluginAccountsPath = join(homedir(), ".opencode", "openai-codex-accounts.json");
 const pluginLogDir = join(homedir(), ".opencode", "logs", "codex-plugin");
 const opencodeCacheDir = join(homedir(), ".opencode", "cache");
 
@@ -252,10 +253,12 @@ async function clearPluginArtifacts() {
 	if (dryRun) {
 		log(`[dry-run] Would remove ${opencodeAuthPath}`);
 		log(`[dry-run] Would remove ${pluginConfigPath}`);
+		log(`[dry-run] Would remove ${pluginAccountsPath}`);
 		log(`[dry-run] Would remove ${pluginLogDir}`);
 	} else {
 		await rm(opencodeAuthPath, { force: true });
 		await rm(pluginConfigPath, { force: true });
+		await rm(pluginAccountsPath, { force: true });
 		await rm(pluginLogDir, { recursive: true, force: true });
 	}
 

--- a/scripts/install-opencode-codex-auth.js
+++ b/scripts/install-opencode-codex-auth.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile, writeFile, mkdir, copyFile, rm } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { parse, modify, applyEdits, printParseErrorCode } from "jsonc-parser";
@@ -59,29 +60,125 @@ const pluginConfigPath = join(
 const pluginAccountsPath = join(homedir(), ".opencode", "openai-codex-accounts.json");
 const pluginLogDir = join(homedir(), ".opencode", "logs", "codex-plugin");
 const opencodeCacheDir = join(homedir(), ".opencode", "cache");
+const compatPluginDir = join(homedir(), ".opencode", "plugins", "codex-auth-bridge");
+const compatPluginShimPath = join(compatPluginDir, "index.mjs");
+const compatPluginEntry = pathToFileURL(compatPluginShimPath).toString();
+const opencodeSourcePluginIndexPath = join(
+	homedir(),
+	".config",
+	"opencode",
+	"opencode",
+	"packages",
+	"opencode",
+	"src",
+	"plugin",
+	"index.ts",
+);
+
+function truthyEnv(name) {
+	const value = process.env[name];
+	if (!value) return false;
+	const normalized = value.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes";
+}
 
 function log(message) {
 	console.log(message);
 }
 
-function normalizePluginList(list) {
+function normalizePluginList(list, desiredEntry) {
 	const entries = Array.isArray(list) ? list.filter(Boolean) : [];
 	const filtered = entries.filter((entry) => {
 		if (typeof entry !== "string") return true;
+		if (entry === desiredEntry) return false;
+		if (entry === compatPluginEntry) return false;
 		return entry !== PLUGIN_NAME && !entry.startsWith(`${PLUGIN_NAME}@`);
 	});
-	return [...filtered, PLUGIN_NAME];
+	return [...filtered, desiredEntry];
 }
 
 function removePluginEntries(list) {
 	const entries = Array.isArray(list) ? list.filter(Boolean) : [];
 	return entries.filter((entry) => {
 		if (typeof entry !== "string") return true;
+		if (entry === compatPluginEntry) {
+			return false;
+		}
 		if (entry === PLUGIN_NAME || entry.startsWith(`${PLUGIN_NAME}@`)) {
 			return false;
 		}
 		return !entry.includes(PLUGIN_NAME);
 	});
+}
+
+function compareSemver(a, b) {
+	const [aMajor, aMinor, aPatch] = a;
+	const [bMajor, bMinor, bPatch] = b;
+	if (aMajor !== bMajor) return aMajor - bMajor;
+	if (aMinor !== bMinor) return aMinor - bMinor;
+	return aPatch - bPatch;
+}
+
+function parseSemver(value) {
+	const match = value.match(/(\d+)\.(\d+)\.(\d+)/);
+	if (!match) return null;
+	return [
+		Number.parseInt(match[1], 10),
+		Number.parseInt(match[2], 10),
+		Number.parseInt(match[3], 10),
+	];
+}
+
+function shouldUseCompatPluginEntry() {
+	if (truthyEnv("OPENCODE_DISABLE_COMPAT_FILE_PLUGIN")) {
+		return { enabled: false, reason: "disabled via env" };
+	}
+	if (truthyEnv("OPENCODE_FORCE_COMPAT_FILE_PLUGIN")) {
+		return { enabled: true, reason: "forced via env" };
+	}
+
+	if (existsSync(opencodeSourcePluginIndexPath)) {
+		try {
+			const source = readFileSync(opencodeSourcePluginIndexPath, "utf-8");
+			if (source.includes("plugin.includes(\"opencode-openai-codex-auth\")")) {
+				return { enabled: true, reason: "detected plugin skip gate in OpenCode source" };
+			}
+		} catch {
+			// Ignore source inspection errors and fall back to version detection.
+		}
+	}
+
+	try {
+		const versionRaw = execFileSync("opencode", ["--version"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+		const parsed = parseSemver(versionRaw);
+		if (parsed && compareSemver(parsed, [1, 1, 56]) >= 0) {
+			return { enabled: true, reason: `OpenCode ${versionRaw} likely contains plugin skip gate` };
+		}
+	} catch {
+		// OpenCode may not be installed yet.
+	}
+
+	return { enabled: false, reason: "no skip gate detected" };
+}
+
+async function ensureCompatPluginShim(targetPath) {
+	const targetUrl = pathToFileURL(targetPath).toString();
+	const content = [
+		`export { default } from ${JSON.stringify(targetUrl)};`,
+		`export * from ${JSON.stringify(targetUrl)};`,
+		"",
+	].join("\n");
+
+	if (dryRun) {
+		log(`[dry-run] Would write compatibility shim at ${compatPluginShimPath}`);
+		return;
+	}
+
+	await mkdir(compatPluginDir, { recursive: true });
+	await writeFile(compatPluginShimPath, content, "utf-8");
 }
 
 function mergeOpenAIConfig(existingOpenAI, templateOpenAI) {
@@ -255,11 +352,13 @@ async function clearPluginArtifacts() {
 		log(`[dry-run] Would remove ${pluginConfigPath}`);
 		log(`[dry-run] Would remove ${pluginAccountsPath}`);
 		log(`[dry-run] Would remove ${pluginLogDir}`);
+		log(`[dry-run] Would remove ${compatPluginDir}`);
 	} else {
 		await rm(opencodeAuthPath, { force: true });
 		await rm(pluginConfigPath, { force: true });
 		await rm(pluginAccountsPath, { force: true });
 		await rm(pluginLogDir, { recursive: true, force: true });
+		await rm(compatPluginDir, { recursive: true, force: true });
 	}
 
 	const cacheFiles = [
@@ -372,7 +471,14 @@ async function main() {
 	}
 
 	const template = await readJson(templatePath);
-	template.plugin = [PLUGIN_NAME];
+	const compatMode = shouldUseCompatPluginEntry();
+	const desiredPluginEntry = compatMode.enabled ? compatPluginEntry : PLUGIN_NAME;
+	template.plugin = [desiredPluginEntry];
+
+	if (compatMode.enabled) {
+		await ensureCompatPluginShim(join(repoRoot, "index.ts"));
+		log(`Compatibility mode enabled: using file plugin shim (${compatMode.reason}).`);
+	}
 
 	let nextConfig = template;
 	let nextContent = null;
@@ -385,7 +491,7 @@ async function main() {
 			const { content, data } = await readJsonc(configPath);
 			const existing = data ?? {};
 			const merged = { ...existing };
-			merged.plugin = normalizePluginList(existing.plugin);
+			merged.plugin = normalizePluginList(existing.plugin, desiredPluginEntry);
 			const provider =
 				existing.provider && typeof existing.provider === "object"
 					? { ...existing.provider }
@@ -422,6 +528,9 @@ async function main() {
 
 	log("\nDone. Restart OpenCode to (re)install the plugin.");
 	log("Example: opencode");
+	if (compatMode.enabled) {
+		log(`Compat plugin entry written: ${compatPluginEntry}`);
+	}
 	if (useLegacy) {
 		log("Note: Legacy config requires OpenCode v1.0.209 or older.");
 	}

--- a/test/account-pool.test.ts
+++ b/test/account-pool.test.ts
@@ -132,4 +132,21 @@ describe("AccountPool", () => {
 		expect((minRetryAfter as number) / 1000).toBeLessThanOrEqual(10);
 		expect((minRetryAfter as number) / 1000).toBeGreaterThan(8);
 	});
+
+	it("supports retry-after HTTP date format", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60_000,
+		});
+		const dateHeader = new Date(Date.now() + 5_000).toUTCString();
+		pool.markRateLimited("a1", new Headers({ "retry-after": dateHeader }));
+
+		const minRetryAfter = pool.getMinRetryAfterMs();
+		expect(minRetryAfter).not.toBeNull();
+		expect(minRetryAfter as number).toBeGreaterThan(2000);
+		expect(minRetryAfter as number).toBeLessThanOrEqual(5000);
+	});
 });

--- a/test/account-pool.test.ts
+++ b/test/account-pool.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AccountPool } from "../lib/account-pool.js";
+
+const testPath = join(tmpdir(), "opencode-openai-codex-auth-account-pool-test.json");
+
+function cleanup(): void {
+	if (existsSync(testPath)) {
+		rmSync(testPath, { force: true });
+	}
+}
+
+describe("AccountPool", () => {
+	beforeEach(() => {
+		process.env.OPENAI_CODEX_ACCOUNTS_PATH = testPath;
+		cleanup();
+	});
+
+	afterEach(() => {
+		cleanup();
+		delete process.env.OPENAI_CODEX_ACCOUNTS_PATH;
+	});
+
+	it("rotates accounts in round-robin mode", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60_000,
+		});
+		pool.upsert({
+			accountId: "a2",
+			access: "access-2",
+			refresh: "refresh-2",
+			expires: Date.now() + 60_000,
+		});
+
+		const one = pool.next("round-robin");
+		const two = pool.next("round-robin");
+		const three = pool.next("round-robin");
+
+		expect(one?.accountId).toBe("a2");
+		expect(two?.accountId).toBe("a1");
+		expect(three?.accountId).toBe("a2");
+	});
+
+	it("keeps same account in sticky mode when available", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60_000,
+		});
+		pool.upsert({
+			accountId: "a2",
+			access: "access-2",
+			refresh: "refresh-2",
+			expires: Date.now() + 60_000,
+		});
+
+		const current = pool.next("sticky");
+		const next = pool.next("sticky");
+
+		expect(current?.accountId).toBeDefined();
+		expect(next?.accountId).toBe(current?.accountId);
+	});
+
+	it("skips rate-limited account and picks another", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60_000,
+		});
+		pool.upsert({
+			accountId: "a2",
+			access: "access-2",
+			refresh: "refresh-2",
+			expires: Date.now() + 60_000,
+		});
+
+		pool.markRateLimited("a2", new Headers({ "retry-after": "60" }));
+		const selected = pool.next("round-robin");
+
+		expect(selected?.accountId).toBe("a1");
+	});
+});

--- a/test/account-pool.test.ts
+++ b/test/account-pool.test.ts
@@ -89,4 +89,47 @@ describe("AccountPool", () => {
 
 		expect(selected?.accountId).toBe("a1");
 	});
+
+	it("does not overwrite newer credentials with stale auth", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: Date.now() + 120_000,
+		});
+		pool.upsert({
+			accountId: "a1",
+			access: "access-old",
+			refresh: "refresh-old",
+			expires: Date.now() + 10_000,
+		});
+
+		const selected = pool.next("sticky");
+		expect(selected?.access).toBe("access-new");
+		expect(selected?.refresh).toBe("refresh-new");
+	});
+
+	it("returns minimum retry-after for limited accounts", () => {
+		const pool = AccountPool.load();
+		pool.upsert({
+			accountId: "a1",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60_000,
+		});
+		pool.upsert({
+			accountId: "a2",
+			access: "access-2",
+			refresh: "refresh-2",
+			expires: Date.now() + 60_000,
+		});
+		pool.markRateLimited("a1", new Headers({ "retry-after": "60" }));
+		pool.markRateLimited("a2", new Headers({ "retry-after": "10" }));
+
+		const minRetryAfter = pool.getMinRetryAfterMs();
+		expect(minRetryAfter).not.toBeNull();
+		expect((minRetryAfter as number) / 1000).toBeLessThanOrEqual(10);
+		expect((minRetryAfter as number) / 1000).toBeGreaterThan(8);
+	});
 });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
 	createState,
 	parseAuthorizationInput,
 	decodeJWT,
 	createAuthorizationFlow,
+	refreshAccessToken,
 	CLIENT_ID,
 	AUTHORIZE_URL,
 	REDIRECT_URI,
@@ -11,6 +12,31 @@ import {
 } from '../lib/auth/auth.js';
 
 describe('Auth Module', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('refreshAccessToken', () => {
+		it('uses existing refresh token when response omits refresh_token', async () => {
+			vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						access_token: 'new-access',
+						expires_in: 3600,
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				),
+			);
+
+			const result = await refreshAccessToken('existing-refresh');
+			expect(result.type).toBe('success');
+			if (result.type === 'success') {
+				expect(result.refresh).toBe('existing-refresh');
+				expect(result.access).toBe('new-access');
+			}
+		});
+	});
+
 	describe('createState', () => {
 		it('should generate a random 32-character hex string', () => {
 			const state = createState();

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -149,6 +149,20 @@ describe('Fetch Helpers Module', () => {
 			expect(json.error.code).toBe('usage_limit_reached');
 		});
 
+		it('maps usage-limit 403 errors to 429', async () => {
+			const body = {
+				error: {
+					code: 'usage_not_included',
+					message: 'account usage is temporarily unavailable',
+				},
+			};
+			const resp = new Response(JSON.stringify(body), { status: 403 });
+			const mapped = await handleErrorResponse(resp);
+			expect(mapped.status).toBe(429);
+			const json = await mapped.json() as any;
+			expect(json.error.code).toBe('usage_not_included');
+		});
+
 		it('leaves non-usage 404 errors unchanged', async () => {
 			const body = { error: { code: 'not_found', message: 'nope' } };
 			const resp = new Response(JSON.stringify(body), { status: 404 });

--- a/test/index-auth-pool.test.ts
+++ b/test/index-auth-pool.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import OpenAIAuthPlugin from "../index.js";
+
+const poolPath = join(tmpdir(), "opencode-openai-codex-auth-oauth-persist-test.json");
+
+function cleanup(): void {
+	if (existsSync(poolPath)) {
+		rmSync(poolPath, { force: true });
+	}
+}
+
+function createJwt(accountId: string, email: string): string {
+	const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+			email,
+		}),
+	).toString("base64url");
+	return `${header}.${payload}.signature`;
+}
+
+describe("OAuth account pool persistence", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		cleanup();
+		delete process.env.OPENAI_CODEX_ACCOUNTS_PATH;
+	});
+
+	it("persists account in pool from manual OAuth callback", async () => {
+		process.env.OPENAI_CODEX_ACCOUNTS_PATH = poolPath;
+		const accessToken = createJwt("account-2", "acc2@example.com");
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					access_token: accessToken,
+					refresh_token: "refresh-2",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const plugin = await OpenAIAuthPlugin({ client: {} as any } as any);
+		const method = plugin.auth?.methods.find((entry) => entry.label.includes("Manual URL Paste"));
+		expect(method).toBeDefined();
+		const flow = await method!.authorize();
+		const result = await flow.callback("manual-code");
+		expect(result.type).toBe("success");
+
+		expect(existsSync(poolPath)).toBe(true);
+		const pool = JSON.parse(readFileSync(poolPath, "utf8")) as {
+			accounts?: Array<{ accountId?: string; email?: string }>;
+		};
+		expect(pool.accounts?.length).toBe(1);
+		expect(pool.accounts?.[0]?.accountId).toBe("account-2");
+		expect(pool.accounts?.[0]?.email).toBe("acc2@example.com");
+	});
+
+	it("retries transient 5xx responses with bounded attempts", async () => {
+		vi.useFakeTimers();
+		process.env.OPENAI_CODEX_ACCOUNTS_PATH = poolPath;
+		const accessToken = createJwt("account-retry", "retry@example.com");
+		const auth = {
+			type: "oauth",
+			access: accessToken,
+			refresh: "refresh-retry",
+			expires: Date.now() + 60_000,
+		} as const;
+
+		const getAuth = vi.fn().mockResolvedValue(auth);
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response("upstream busy", { status: 503 }))
+			.mockResolvedValueOnce(new Response("still busy", { status: 502 }))
+			.mockResolvedValueOnce(new Response("still failing", { status: 503 }));
+
+		const plugin = await OpenAIAuthPlugin({
+			client: { auth: { set: vi.fn() } } as any,
+		} as any);
+		const loaded = await plugin.auth!.loader(getAuth, {
+			options: { accountSelectionStrategy: "sticky" },
+		});
+
+		const responsePromise = loaded.fetch("https://api.openai.com/v1/responses", {
+			method: "GET",
+		});
+		await vi.runAllTimersAsync();
+		const response = await responsePromise;
+
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(response.status).toBe(503);
+	});
+});

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -7,9 +7,14 @@ import { parse } from 'jsonc-parser';
 
 const SCRIPT_PATH = resolve(process.cwd(), 'scripts', 'install-opencode-codex-auth.js');
 
-const runInstaller = (args: string[], homeDir: string) => {
+const runInstaller = (args: string[], homeDir: string, extraEnv: Record<string, string> = {}) => {
 	execFileSync(process.execPath, [SCRIPT_PATH, ...args], {
-		env: { ...process.env, HOME: homeDir },
+		env: {
+			...process.env,
+			HOME: homeDir,
+			OPENCODE_DISABLE_COMPAT_FILE_PLUGIN: '1',
+			...extraEnv,
+		},
 		stdio: 'pipe',
 	});
 };
@@ -144,5 +149,24 @@ describe('Install script', () => {
 		expect(existsSync(join(opencodeDir, 'openai-codex-auth-config.json'))).toBe(false);
 		expect(existsSync(join(opencodeDir, 'logs', 'codex-plugin'))).toBe(false);
 		expect(existsSync(join(opencodeDir, 'cache', 'codex-instructions.md'))).toBe(false);
+	});
+
+	it('writes compatibility file:// plugin shim when forced', () => {
+		const homeDir = makeHome();
+		runInstaller(['--no-cache-clear'], homeDir, {
+			OPENCODE_FORCE_COMPAT_FILE_PLUGIN: '1',
+			OPENCODE_DISABLE_COMPAT_FILE_PLUGIN: '0',
+		});
+
+		const configPath = join(homeDir, '.config', 'opencode', 'opencode.jsonc');
+		const { data } = readJsoncFile(configPath);
+		expect(data.plugin[0]).toContain('file://');
+		expect(data.plugin[0]).toContain('/.opencode/plugins/codex-auth-bridge/index.mjs');
+
+		const shimPath = join(homeDir, '.opencode', 'plugins', 'codex-auth-bridge', 'index.mjs');
+		expect(existsSync(shimPath)).toBe(true);
+		const shim = readFileSync(shimPath, 'utf-8');
+		expect(shim).toContain('export { default } from');
+		expect(shim).toContain('index.ts');
 	});
 });

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -39,7 +39,11 @@ describe('Plugin Configuration', () => {
 
 			const config = loadPluginConfig();
 
-			expect(config).toEqual({ codexMode: true });
+			expect(config).toEqual({
+				codexMode: true,
+				accountSelectionStrategy: 'round-robin',
+				rateLimitCooldownMs: 60000,
+			});
 			expect(mockExistsSync).toHaveBeenCalledWith(
 				path.join(os.homedir(), '.opencode', 'openai-codex-auth-config.json')
 			);
@@ -51,7 +55,11 @@ describe('Plugin Configuration', () => {
 
 			const config = loadPluginConfig();
 
-			expect(config).toEqual({ codexMode: false });
+			expect(config).toEqual({
+				codexMode: false,
+				accountSelectionStrategy: 'round-robin',
+				rateLimitCooldownMs: 60000,
+			});
 		});
 
 		it('should merge user config with defaults', () => {
@@ -60,7 +68,11 @@ describe('Plugin Configuration', () => {
 
 			const config = loadPluginConfig();
 
-			expect(config).toEqual({ codexMode: true });
+			expect(config).toEqual({
+				codexMode: true,
+				accountSelectionStrategy: 'round-robin',
+				rateLimitCooldownMs: 60000,
+			});
 		});
 
 		it('should handle invalid JSON gracefully', () => {
@@ -70,7 +82,11 @@ describe('Plugin Configuration', () => {
 			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			const config = loadPluginConfig();
 
-			expect(config).toEqual({ codexMode: true });
+			expect(config).toEqual({
+				codexMode: true,
+				accountSelectionStrategy: 'round-robin',
+				rateLimitCooldownMs: 60000,
+			});
 			expect(consoleSpy).toHaveBeenCalled();
 			consoleSpy.mockRestore();
 		});
@@ -84,7 +100,11 @@ describe('Plugin Configuration', () => {
 			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			const config = loadPluginConfig();
 
-			expect(config).toEqual({ codexMode: true });
+			expect(config).toEqual({
+				codexMode: true,
+				accountSelectionStrategy: 'round-robin',
+				rateLimitCooldownMs: 60000,
+			});
 			expect(consoleSpy).toHaveBeenCalled();
 			consoleSpy.mockRestore();
 		});


### PR DESCRIPTION
## Summary
- add a persisted multi-account pool at `~/.opencode/openai-codex-accounts.json` and auto-merge newly logged-in OAuth accounts
- implement account selection strategies (`round-robin` default, `sticky` optional) with automatic rotation on 429/usage-limit responses
- refresh tokens per selected account, persist rotation state, and document new config/installer cleanup behavior

## Validation
- `npm test` (232 passed)
- `npm run typecheck`
- `npm run build`
- smoke-tested local OpenCode config: `opencode run "ping" --model=openai/gpt-5.2 --variant=medium` -> `pong`