### PR TITLE
feat: add GPT-5.6/5.5/5.4 model support for current ChatGPT backend

### DIFF
--- a/config/opencode-legacy.json
+++ b/config/opencode-legacy.json
@@ -15,6 +15,481 @@
         "store": false
       },
       "models": {
+        "gpt-5.6-luna-low": {
+          "name": "GPT 5.6 Luna Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-luna-medium": {
+          "name": "GPT 5.6 Luna Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-luna-high": {
+          "name": "GPT 5.6 Luna High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-luna-xhigh": {
+          "name": "GPT 5.6 Luna Xhigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-terra-low": {
+          "name": "GPT 5.6 Terra Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-terra-medium": {
+          "name": "GPT 5.6 Terra Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-terra-high": {
+          "name": "GPT 5.6 Terra High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-terra-xhigh": {
+          "name": "GPT 5.6 Terra Xhigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-sol-low": {
+          "name": "GPT 5.6 Sol Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-sol-medium": {
+          "name": "GPT 5.6 Sol Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-sol-high": {
+          "name": "GPT 5.6 Sol High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.6-sol-xhigh": {
+          "name": "GPT 5.6 Sol Xhigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-low": {
+          "name": "GPT 5.5 Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-medium": {
+          "name": "GPT 5.5 Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-high": {
+          "name": "GPT 5.5 High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-xhigh": {
+          "name": "GPT 5.5 Xhigh (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-mini-low": {
+          "name": "GPT 5.4 Mini Low (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-mini-medium": {
+          "name": "GPT 5.4 Mini Medium (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-mini-high": {
+          "name": "GPT 5.4 Mini High (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.2-none": {
           "name": "GPT 5.2 None (OAuth)",
           "limit": {

--- a/config/opencode-modern.json
+++ b/config/opencode-modern.json
@@ -15,6 +15,191 @@
         "store": false
       },
       "models": {
+        "gpt-5.6-luna": {
+          "name": "GPT 5.6 Luna (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "low"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.6-terra": {
+          "name": "GPT 5.6 Terra (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "low"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "low"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.5": {
+          "name": "GPT 5.5 (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "low"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.4-mini": {
+          "name": "GPT 5.4 Mini (OAuth)",
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "low"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
         "gpt-5.2": {
           "name": "GPT 5.2 (OAuth)",
           "limit": {

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -18,6 +18,9 @@ const __dirname = dirname(__filename);
  * Maps to different system prompts in the Codex CLI
  */
 export type ModelFamily =
+	| "gpt-5.6"
+	| "gpt-5.5"
+	| "gpt-5.4"
 	| "gpt-5.2-codex"
 	| "codex-max"
 	| "codex"
@@ -29,6 +32,9 @@ export type ModelFamily =
  * Based on codex-rs/core/src/model_family.rs logic
  */
 const PROMPT_FILES: Record<ModelFamily, string> = {
+	"gpt-5.6": "gpt_5_1_prompt.md",
+	"gpt-5.5": "gpt_5_1_prompt.md",
+	"gpt-5.4": "gpt_5_1_prompt.md",
 	"gpt-5.2-codex": "gpt-5.2-codex_prompt.md",
 	"codex-max": "gpt-5.1-codex-max_prompt.md",
 	codex: "gpt_5_codex_prompt.md",
@@ -40,6 +46,9 @@ const PROMPT_FILES: Record<ModelFamily, string> = {
  * Cache file mapping for each model family
  */
 const CACHE_FILES: Record<ModelFamily, string> = {
+	"gpt-5.6": "gpt-5.1-instructions.md",
+	"gpt-5.5": "gpt-5.1-instructions.md",
+	"gpt-5.4": "gpt-5.1-instructions.md",
 	"gpt-5.2-codex": "gpt-5.2-codex-instructions.md",
 	"codex-max": "codex-max-instructions.md",
 	codex: "codex-instructions.md",
@@ -59,6 +68,15 @@ export function getModelFamily(normalizedModel: string): ModelFamily {
 		normalizedModel.includes("gpt 5.2 codex")
 	) {
 		return "gpt-5.2-codex";
+	}
+	if (normalizedModel.includes("gpt-5.6") || normalizedModel.includes("gpt 5.6")) {
+		return "gpt-5.6";
+	}
+	if (normalizedModel.includes("gpt-5.5") || normalizedModel.includes("gpt 5.5")) {
+		return "gpt-5.5";
+	}
+	if (normalizedModel.includes("gpt-5.4") || normalizedModel.includes("gpt 5.4")) {
+		return "gpt-5.4";
 	}
 	if (normalizedModel.includes("codex-max")) {
 		return "codex-max";

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -12,9 +12,49 @@
  * Value: The normalized model name to send to the API
  */
 export const MODEL_MAP: Record<string, string> = {
-// ============================================================================
-// GPT-5.1 Codex Models
-// ============================================================================
+	// ============================================================================
+	// GPT-5.6 Models (current ChatGPT Codex backend)
+	// ============================================================================
+	"gpt-5.6-luna": "gpt-5.6-luna",
+	"gpt-5.6-terra": "gpt-5.6-terra",
+	"gpt-5.6-sol": "gpt-5.6-sol",
+	"gpt-5.6-luna-low": "gpt-5.6-luna",
+	"gpt-5.6-luna-medium": "gpt-5.6-luna",
+	"gpt-5.6-luna-high": "gpt-5.6-luna",
+	"gpt-5.6-luna-xhigh": "gpt-5.6-luna",
+	"gpt-5.6-terra-low": "gpt-5.6-terra",
+	"gpt-5.6-terra-medium": "gpt-5.6-terra",
+	"gpt-5.6-terra-high": "gpt-5.6-terra",
+	"gpt-5.6-terra-xhigh": "gpt-5.6-terra",
+	"gpt-5.6-sol-low": "gpt-5.6-sol",
+	"gpt-5.6-sol-medium": "gpt-5.6-sol",
+	"gpt-5.6-sol-high": "gpt-5.6-sol",
+	"gpt-5.6-sol-xhigh": "gpt-5.6-sol",
+
+	// ============================================================================
+	// GPT-5.5 Models
+	// ============================================================================
+	"gpt-5.5": "gpt-5.5",
+	"gpt-5.5-low": "gpt-5.5",
+	"gpt-5.5-medium": "gpt-5.5",
+	"gpt-5.5-high": "gpt-5.5",
+	"gpt-5.5-xhigh": "gpt-5.5",
+
+	// ============================================================================
+	// GPT-5.4 Models
+	// ============================================================================
+	"gpt-5.4": "gpt-5.4",
+	"gpt-5.4-low": "gpt-5.4",
+	"gpt-5.4-medium": "gpt-5.4",
+	"gpt-5.4-high": "gpt-5.4",
+	"gpt-5.4-mini": "gpt-5.4-mini",
+	"gpt-5.4-mini-low": "gpt-5.4-mini",
+	"gpt-5.4-mini-medium": "gpt-5.4-mini",
+	"gpt-5.4-mini-high": "gpt-5.4-mini",
+
+	// ============================================================================
+	// GPT-5.1 Codex Models
+	// ============================================================================
 	"gpt-5.1-codex": "gpt-5.1-codex",
 	"gpt-5.1-codex-low": "gpt-5.1-codex",
 	"gpt-5.1-codex-medium": "gpt-5.1-codex",

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -47,6 +47,24 @@ export function normalizeModel(model: string | undefined): string {
 	const normalized = modelId.toLowerCase();
 
 	// Priority order for pattern matching (most specific first):
+	// 0. GPT-5.6 family (current ChatGPT Codex backend)
+	if (normalized.includes("gpt-5.6")) {
+		return "gpt-5.6";
+	}
+
+	// 0b. GPT-5.5 family
+	if (normalized.includes("gpt-5.5")) {
+		return "gpt-5.5";
+	}
+
+	// 0c. GPT-5.4 family
+	if (normalized.includes("gpt-5.4-mini")) {
+		return "gpt-5.4-mini";
+	}
+	if (normalized.includes("gpt-5.4")) {
+		return "gpt-5.4";
+	}
+
 	// 1. GPT-5.2 Codex (newest codex model)
 	if (
 		normalized.includes("gpt-5.2-codex") ||


### PR DESCRIPTION
The ChatGPT Codex backend has migrated to the gpt-5.6 family (gpt-5.6-luna/terra/sol), gpt-5.5 and gpt-5.4-mini. The current plugin normalizes these new model names down to the deprecated gpt-5.1, which the backend rejects with: `The gpt-5.1 model is not supported when using Codex with a ChatGPT account.`

Changes:
- Add model mappings for gpt-5.6-luna/terra/sol, gpt-5.5, gpt-5.4-mini (+ reasoning variants)
- Fix normalizeModel fallback pattern order so new models pass through unchanged
- Extend ModelFamily type with new families and map them to the gpt-5.1 prompt/instructions files
- Add new model presets to config/opencode-modern.json and config/opencode-legacy.json

Verified working with ChatGPT Plus OAuth: chat requests and the gpt-image-1.5 image generation endpoint both succeed.